### PR TITLE
Disable the failure trace button when there is no failure.

### DIFF
--- a/src/main/org/testng/eclipse/ui/FailureTrace.java
+++ b/src/main/org/testng/eclipse/ui/FailureTrace.java
@@ -36,6 +36,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.swt.widgets.ToolBar;
+import org.testng.ITestResult;
 import org.testng.eclipse.TestNGPlugin;
 
 /**
@@ -183,7 +184,7 @@ class FailureTrace implements IMenuListener {
    */
   public void showFailure(RunInfo failure) {
 //    System.out.println("showFailure");
-    if(null == failure) {
+    if(null == failure || failure.getStatus() != ITestResult.FAILURE) {
       fCompareAction.setEnabled(false);
       clear();
       return;


### PR DESCRIPTION
This change will disable the failure button, since before it was failing when a stacktrace is null (which clearly is correct) because no stack trace exists.

My first patch :) Eclipse plugin is cool!
