### PR TITLE
fixed usage of method selector in creating xml file from template

### DIFF
--- a/src/main/org/testng/eclipse/util/CustomSuite.java
+++ b/src/main/org/testng/eclipse/util/CustomSuite.java
@@ -198,7 +198,7 @@ abstract public class CustomSuite extends LaunchSuite {
               Properties p = new Properties();
               p.put("name", cls);
               p.put("priority", ms.getPriority());
-              suiteBuffer.push("selector-class", p);
+              suiteBuffer.addEmptyElement("selector-class", p);
               suiteBuffer.pop("method-selector");
             }
             // TODO: <script> tag of method-selector


### PR DESCRIPTION
Trying to specify method selectors in the xml template was not working, Eclipse complained about popping unexpected things.
