### PR TITLE
Use Execution Environment instead of JRE

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -5,6 +5,6 @@
 	<classpathentry exported="true" kind="lib" path="lib/testng.jar" sourcepath="/testng"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="lib" path="lib/junit-4.8.2.jar" sourcepath="/Users/cbeust/.m2/repository/junit/junit/4.8.2/junit-4.8.2-sources.jar"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.launching.macosx.MacOSXType/JVM 1.5.0"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
 	<classpathentry kind="output" path="build/classes"/>
 </classpath>


### PR DESCRIPTION
Execution environments [1] are symbolic representations of JREs. For
example, rather than talking about a specific JRE, with a specific
name at a specific location on your disk, you can talk about the
J2SE-1.4 execution environment. The system can then be configured to
use a specific JRE to implement that execution environment.

One of the reasons why EE was introduced, is to make projects'
development easier on different platforms. Current
'o.e.j.internal.launching.macosx.MacOSXType' is Mac-specific while
o.e.j.internal.debug.ui.launcher.StandardVMType is a more generic.

[1] http://wiki.eclipse.org/index.php/Execution_Environments

Signed-off-by: Mykola Nikishov mn@mn.com.ua
