### PR TITLE
Fix for 'Context Menu Contributions All Over/Inconsistent' issue

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -376,7 +376,8 @@
 
         <menu label="TestNG">
           <visibleWhen>
-              <iterate>
+              <iterate
+                    ifEmpty="false">
                  <adapt type="org.eclipse.jdt.core.IJavaElement">
                    <instanceof value="org.eclipse.jdt.core.IJavaElement" />
                  </adapt>
@@ -399,7 +400,8 @@
        <menu label="TestNG">
           <visibleWhen>
             <with variable="selection">
-              <iterate>
+              <iterate
+                    ifEmpty="false">
                  <adapt type="org.eclipse.core.resources.IFile">
                    <test property="org.eclipse.core.resources.name" value="*.xml"/>
                    <test property="org.testng.eclipse.isXmlSuite"/>


### PR DESCRIPTION
Issue #13 fixes #15 only partially, manandbytes@493adc44 hides these 'TestNG' context menus if nothing had been selected. You can cherry pick just 493adc4.
