### PR TITLE
Disable 'TestNG' context menus if the selection is empty

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -376,7 +376,8 @@
 
         <menu label="TestNG">
           <visibleWhen>
-              <iterate>
+              <iterate
+                    ifEmpty="false">
                  <adapt type="org.eclipse.jdt.core.IJavaElement">
                    <instanceof value="org.eclipse.jdt.core.IJavaElement" />
                  </adapt>
@@ -399,7 +400,8 @@
        <menu label="TestNG">
           <visibleWhen>
             <with variable="selection">
-              <iterate>
+              <iterate
+                    ifEmpty="false">
                  <adapt type="org.eclipse.core.resources.IFile">
                    <test property="org.eclipse.core.resources.name" value="*.xml"/>
                    <test property="org.testng.eclipse.isXmlSuite"/>


### PR DESCRIPTION
These context menus are enabled based on visibleWhen expression that
checks that the current selection can be processed by
TestNG. visibleWhen expression uses iterate to check against multiple
conditions and, by default, iterate will return true if the selection
is empty. This way TestNG menu contributions are always enabled.

Explicitly instruct iterate to return false if the selection is
empty.

Signed-off-by: Mykola Nikishov mn@mn.com.ua
