### PR TITLE
TestNG groups run configuration fix

### DIFF
--- a/src/main/org/testng/eclipse/launch/GroupSelector.java
+++ b/src/main/org/testng/eclipse/launch/GroupSelector.java
@@ -104,6 +104,7 @@ public class GroupSelector extends MultiSelector {
       for(int i = 0; i < groupNames.size(); i++) {
         m_groupMap.put(groupNames.get(i), groupClassNames);
       }
+      getValueMap().putAll(m_groupMap);
     }
   }
 


### PR DESCRIPTION
Hi Cedric,

I've faced a problem with groups run configuration and found a way to fix it. See below for details.

Problem: a user creates a new TestNG run configuration and selects some groups to run. The user runs the configuration and opens it again
and press the "Run" button, but no tests are run.

Solution: all data from m_groupMap of GroupSelector has been copied to valueMap of MultiSelector in the initializeFrom method.

Regards,
Bogdan.
