### PR TITLE
Implement the user pre defined listeners feature.

### DIFF
--- a/src/main/org/testng/eclipse/TestNGMessages.properties
+++ b/src/main/org/testng/eclipse/TestNGMessages.properties
@@ -117,6 +117,8 @@ TestNGPropertyPage.outputDir=Output directory:
 TestNGPropertyPage.templateXml=Template XML file:
 TestNGPropertyPage.watchResultXml=Watch testng-results.xml
 TestNGPropertyPage.resultXmlDirectory=Directory:
+TestNGPropertyPage.preDefinedListeners=Pre Defined Listeners:
+
 
 NewTestNGClassWizardPage.title=New TestNG class
 NewTestNGClassWizardPage.description=Specify additional information about the test class.

--- a/src/main/org/testng/eclipse/TestNGPluginConstants.java
+++ b/src/main/org/testng/eclipse/TestNGPluginConstants.java
@@ -27,7 +27,7 @@ public abstract class TestNGPluginConstants {
   public static final String S_JVM_ARGS = "jvmArgs";
   public static final String S_EXCLUDED_STACK_TRACES = "excludedStackTraces";
   public static final String S_SUITE_METHOD_TREATMENT = "suiteMethodTreatment";
-
+  public static final String S_PRE_DEFINED_LISTENERS = "preDefinedListeners";
 
   private TestNGPluginConstants() {}
 }

--- a/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationConstants.java
+++ b/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationConstants.java
@@ -94,6 +94,8 @@ public abstract class TestNGLaunchConfigurationConstants {
   
   public static final String VM_ENABLEASSERTION_OPTION = "-ea";
   
+  public static final String PRE_DEFINED_LISTENERS=
+      make("PRE_DEFINED_LISTENERS");
   // What kind of run we are doing
   // This would be a nice place for an enum when jdk1.5 or later can be 
   // required.

--- a/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationDelegate.java
+++ b/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationDelegate.java
@@ -215,16 +215,32 @@ public class TestNGLaunchConfigurationDelegate extends AbstractJavaLaunchConfigu
 //      }
 //    }
 
+    
     PreferenceStoreUtil storage = TestNGPlugin.getPluginPreferenceStore();
     argv.add(CommandLineArgs.OUTPUT_DIRECTORY);
     argv.add(storage.getOutputAbsolutePath(jproject).toOSString());
 
+    
 //    String reporters = storage.getReporters(project.getName(), false);
 //    if (null != reporters && !"".equals(reporters)) {
 //      argv.add(TestNGCommandLineArgs.LISTENER_COMMAND_OPT);
 //      argv.add(reporters.replace(' ', ';'));
 //    }
+    
+    String preDefinedListeners = configuration.getAttribute(TestNGLaunchConfigurationConstants.PRE_DEFINED_LISTENERS,"");
+    
+    if (!preDefinedListeners.trim().equals("")){
+      if (!argv.contains(CommandLineArgs.LISTENER)) {
+        argv.add(CommandLineArgs.LISTENER);
+        argv.add(preDefinedListeners);
+      } else {
+        String listeners = argv.get(argv.size() - 1);
+        listeners += (";" + preDefinedListeners);
+        argv.set(argv.size() - 1, listeners);
+      }
+    }
 
+    
     List<ITestNGListener> contributors = ListenerContributorUtil.findReporterContributors();
     contributors.addAll(ListenerContributorUtil.findTestContributors());
     StringBuffer reportersContributors = new StringBuffer();

--- a/src/main/org/testng/eclipse/ui/preferences/ProjectPropertyPage.java
+++ b/src/main/org/testng/eclipse/ui/preferences/ProjectPropertyPage.java
@@ -1,5 +1,8 @@
 package org.testng.eclipse.ui.preferences;
 
+import java.io.File;
+import java.util.ArrayList;
+
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
@@ -41,9 +44,6 @@ import org.testng.eclipse.util.PreferenceStoreUtil;
 import org.testng.eclipse.util.SWTUtil;
 import org.testng.reporters.XMLReporter;
 
-import java.io.File;
-import java.util.ArrayList;
-
 /**
  * Project specific properties.
  *
@@ -55,6 +55,7 @@ public class ProjectPropertyPage extends PropertyPage {
   private Button m_absolutePath;
   private Button m_disabledDefaultListeners;
   private Text m_xmlTemplateFile;
+  private Text m_preDefinedListeners;
   private IProject m_workingProject;
   private Button m_projectJar;
   private Text m_watchResultText;
@@ -154,6 +155,7 @@ public class ProjectPropertyPage extends PropertyPage {
 //    m_disabledDefaultListeners.setLayoutData(SWTUtil.createGridData());//new GridData(SWT.FILL, SWT.NONE, true, false, 4, 1));
 //    m_disabledDefaultListeners.setBackground(new Color(parent.getDisplay(), 0xcc, 0, 0));
 
+    
     //
     // Project jar
     //
@@ -163,7 +165,13 @@ public class ProjectPropertyPage extends PropertyPage {
 //        false /* don't grab excess horizontal */,
 //        false /* don't grab excess vertical */,
 //        2, 1));
-
+    
+    //Create a string editor control: A label and a text area
+    {
+      Widgets w = Utils.createStringEditorControl(parentComposite, "TestNGPropertyPage.preDefinedListeners", null, true);
+      m_preDefinedListeners = w.text;
+      m_preDefinedListeners.setToolTipText("Split multi listener using ;");
+    }
     loadDefaults();
 
     return parentComposite;
@@ -176,6 +184,7 @@ public class ProjectPropertyPage extends PropertyPage {
     m_absolutePath.dispose();
     m_disabledDefaultListeners.dispose();
     m_xmlTemplateFile.dispose();
+    m_preDefinedListeners.dispose();
     
     super.dispose();
   }
@@ -194,6 +203,7 @@ public class ProjectPropertyPage extends PropertyPage {
     m_watchResultRadio.setSelection(storage.getWatchResults(projectName));
     String dir = storage.getWatchResultDirectory(projectName);
     m_watchResultText.setText(dir);
+    m_preDefinedListeners.setText(storage.getPreDefinedListeners(projectName, false));
   }
 
   protected void performDefaults() {
@@ -207,6 +217,7 @@ public class ProjectPropertyPage extends PropertyPage {
     storage.storeOutputDir(projectName, m_outputdir.getText(), m_absolutePath.getSelection());
     storage.storeDisabledListeners(projectName, m_disabledDefaultListeners.getSelection());
     storage.storeXmlTemplateFile(projectName, m_xmlTemplateFile.getText());
+    storage.storePreDefinedListeners(projectName, m_preDefinedListeners.getText());
     storage.storeUseProjectJar(projectName, m_projectJar.getSelection());
     storage.storeWatchResults(projectName, m_watchResultRadio.getSelection());
     storage.storeWatchResultLocation(projectName, m_watchResultText.getText());

--- a/src/main/org/testng/eclipse/ui/preferences/WorkspacePreferencePage.java
+++ b/src/main/org/testng/eclipse/ui/preferences/WorkspacePreferencePage.java
@@ -32,6 +32,7 @@ public class WorkspacePreferencePage
   private BooleanFieldEditor2 m_disabledDefaultListeners;
   private FileFieldEditor m_xmlTemplateFile;
   private StringFieldEditor m_excludedStackTraces;
+  private StringFieldEditor m_preDefinedListeners;
   
   public WorkspacePreferencePage() {
     super(GRID);
@@ -87,11 +88,15 @@ public class WorkspacePreferencePage
         .hint(convertWidthInCharsToPixels(36), SWT.DEFAULT)
         .applyTo(m_excludedStackTraces.getTextControl(parentComposite));
 
+    m_preDefinedListeners = new StringFieldEditor(TestNGPluginConstants.S_PRE_DEFINED_LISTENERS,
+        "Pre Defined Listeners", parentComposite);
+
     addField(m_outputdir);
     addField(m_absolutePath);
     addField(m_disabledDefaultListeners);    
     addField(m_xmlTemplateFile);
     addField(m_excludedStackTraces);
+    addField(m_preDefinedListeners);
   }
 
   /* (non-Javadoc)

--- a/src/main/org/testng/eclipse/ui/util/Utils.java
+++ b/src/main/org/testng/eclipse/ui/util/Utils.java
@@ -123,6 +123,35 @@ public class Utils {
     enableControls(result, enabled);
     return result;
   }
+  
+  
+  /**
+   * Create a line of widgets, made of:
+   * - A label
+   * - A text field
+   */
+  public static Widgets createStringEditorControl(Composite suppliedParent,
+      String labelKey, ModifyListener textListener, boolean enabled){
+    
+    final Widgets result = new Widgets();
+    Composite parent = createParent(suppliedParent, true);
+    //
+    // Label
+    //
+    Label label = new Label(parent, SWT.NULL);
+    label.setText(ResourceUtil.getString(labelKey));
+
+    //
+    // Text widget
+    //
+    result.text = new Text(parent, SWT.SINGLE | SWT.BORDER);
+    GridData gd = new GridData(GridData.HORIZONTAL_ALIGN_FILL | GridData.GRAB_HORIZONTAL);
+    result.text.setLayoutData(gd);
+    if (textListener != null) result.text.addModifyListener(textListener);
+    
+    enableControls(result, enabled);
+    return result;
+  }
 
   private static void enableControls(Widgets result, boolean enabled) {
     if (result.text != null) result.text.setEnabled(enabled);

--- a/src/main/org/testng/eclipse/util/LaunchUtil.java
+++ b/src/main/org/testng/eclipse/util/LaunchUtil.java
@@ -11,11 +11,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Sets;
-
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -55,6 +50,11 @@ import org.testng.eclipse.ui.util.ConfigurationHelper;
 import org.testng.eclipse.util.JDTUtil.MethodDefinition;
 import org.testng.eclipse.util.param.ParameterSolver;
 import org.testng.reporters.FailedReporter;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 
 /**
  * An utility class that centralize the work about configuration launchers.
@@ -130,7 +130,6 @@ public class LaunchUtil {
 		  String mode, ILaunchConfiguration prevConfig, Set failureDescriptions) {
     ILaunchConfigurationWorkingCopy configWC =
         createLaunchConfiguration(project, fileConfName, null);
-
     try {
       if (prevConfig != null) {
         Map<?, ?> previousEnv
@@ -144,6 +143,8 @@ public class LaunchUtil {
     configWC.setAttribute(TestNGLaunchConfigurationConstants.SUITE_TEST_LIST,
                           Collections.singletonList(suiteFilePath));
     configWC.setAttribute(TestNGLaunchConfigurationConstants.TYPE, LaunchType.SUITE.ordinal());
+
+
     // carry over jvm args from prevConfig
     // set failed test jvm args
     String jargs = ConfigurationHelper.getJvmArgs(prevConfig);
@@ -238,6 +239,12 @@ public class LaunchUtil {
         ConfigurationHelper.toClassMethodsMap(new HashMap<String, Collection<String>>()));
     workingCopy.setAttribute(TestNGLaunchConfigurationConstants.PARAMS,
                              solveParameters(ipf));
+
+    String projectName= ijp.getProject().getName();
+    
+    PreferenceStoreUtil storage = TestNGPlugin.getPluginPreferenceStore();
+    String preDefinedListeners = storage.getPreDefinedListeners(projectName, false);
+    workingCopy.setAttribute(TestNGLaunchConfigurationConstants.PRE_DEFINED_LISTENERS, preDefinedListeners.toString().trim());
 
     runConfig(workingCopy, mode);
   }
@@ -339,6 +346,12 @@ public class LaunchUtil {
                              solveParameters(methods));
 //    workingCopy.setAttribute(TestNGLaunchConfigurationConstants.TESTNG_COMPLIANCE_LEVEL_ATTR,
 //                             complianceLevel);
+    String projectName= ijp.getProject().getName();
+    
+    PreferenceStoreUtil storage = TestNGPlugin.getPluginPreferenceStore();
+    String preDefinedListeners = storage.getPreDefinedListeners(projectName, false);
+    workingCopy.setAttribute(TestNGLaunchConfigurationConstants.PRE_DEFINED_LISTENERS, preDefinedListeners.toString().trim());
+
     if (runInfo != null) {
     	// set the class and method
     	
@@ -413,6 +426,7 @@ public class LaunchUtil {
 
   private static void launchTypeBasedConfiguration(IJavaProject javaProject, String confName,
       IType[] types, String mode) {
+    
     Multimap<String, String> classMethods = ArrayListMultimap.create();
     List<String> typeNames = Lists.newArrayList();
     Set<IType> allTypes = Sets.newHashSet();
@@ -455,6 +469,13 @@ public class LaunchUtil {
         methodNames);
     workingCopy.setAttribute(TestNGLaunchConfigurationConstants.PACKAGE_TEST_LIST,
                              EMPTY_ARRAY_PARAM);
+    
+    String projectName= javaProject.getProject().getName();
+    
+    PreferenceStoreUtil storage = TestNGPlugin.getPluginPreferenceStore();
+    String preDefinedListeners = storage.getPreDefinedListeners(projectName, false);
+    workingCopy.setAttribute(TestNGLaunchConfigurationConstants.PRE_DEFINED_LISTENERS, preDefinedListeners.toString().trim());
+
 
     runConfig(workingCopy, mode);
   }
@@ -650,7 +671,6 @@ public class LaunchUtil {
 
   private static void runConfig(ILaunchConfigurationWorkingCopy launchConfiguration, String runMode) {
     ILaunchConfiguration conf= save(launchConfiguration);
-    
     if(null != conf) {
 //      try {
 //        Map attrs= conf.getAttributes();

--- a/src/main/org/testng/eclipse/util/PreferenceStoreUtil.java
+++ b/src/main/org/testng/eclipse/util/PreferenceStoreUtil.java
@@ -41,6 +41,10 @@ public class PreferenceStoreUtil {
   public void storeXmlTemplateFile(String projectName, String xmlFile) {
     m_storage.setValue(projectName + TestNGPluginConstants.S_XML_TEMPLATE_FILE, xmlFile);
   }
+  
+  public void storePreDefinedListeners(String projectName, String listeners){
+    m_storage.setValue(projectName + TestNGPluginConstants.S_PRE_DEFINED_LISTENERS, listeners);
+  }
 
   public String getExcludedStackTraces(String projectName) {
     return getString(projectName, false, TestNGPluginConstants.S_EXCLUDED_STACK_TRACES);
@@ -56,6 +60,10 @@ public class PreferenceStoreUtil {
   
   public String getXmlTemplateFile(String projectName, boolean projectOnly) {
     return getString(projectName, projectOnly, TestNGPluginConstants.S_XML_TEMPLATE_FILE);
+  }
+  
+  public String getPreDefinedListeners(String projectName, boolean projectOnly){
+    return getString(projectName, projectOnly, TestNGPluginConstants.S_PRE_DEFINED_LISTENERS);
   }
 
   public IPath getOutputDirectoryPath(IJavaProject project) {


### PR DESCRIPTION
Hi Cedric,

Currently, when we want to run a method, class uring testng plugin, we can not config the listeners except define those info in the runner info. (This is a very bad user experience, how about make this process easier)

In normal times, most users we have some fixed listeners, in our team, we have two listeners. I create a preference item for listeners, users can define their preference listeners into here. 

When they start to run the case (method, class.. except run the xml files), they do not need to define the listeners. This will be very convenient for everyone :)

Hope this could be merged.

Br,
Tim
