### PR TITLE
set forcePluginActivation to true in property tester

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -92,7 +92,7 @@
                       <test property="org.eclipse.debug.ui.matchesPattern" value="*.class"/>
                       <instanceof value="org.eclipse.jdt.core.IJavaElement"/>
                     </or>
-                    <test property="org.testng.eclipse.isTest"/>
+                    <test property="org.testng.eclipse.isTest" forcePluginActivation="true"/>
                   </iterate>
                </with>
             </enablement>


### PR DESCRIPTION
Ensure property tester is always used, otherwise it will always return
true until something else causes the plugin to be initialized.
