### PR TITLE
a comma was being added to the end of one-item lists, preventing method selection

### DIFF
--- a/src/main/org/testng/eclipse/util/StringUtils.java
+++ b/src/main/org/testng/eclipse/util/StringUtils.java
@@ -1,6 +1,7 @@
 package org.testng.eclipse.util;
 
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 
 import com.google.common.collect.Lists;
@@ -39,8 +40,14 @@ public class StringUtils {
     StringBuffer result = new StringBuffer();
 
     if(null != l) {
-      for (String s : l) {
-        result.append(s).append(",");
+      Iterator<String> iter = l.iterator();
+      while(iter.hasNext()) {
+        String s = iter.next();
+        result.append(s);
+        // only append if it's not the last entry
+        if(iter.hasNext()) {
+          result.append(",");
+        }
       }
     }
 


### PR DESCRIPTION
Pretty simple fix, but the symptom was that you couldn't select a method in the Launch Configuration because it had a comma at the end (i.e., `MyTest,`), so the method selection algorithm would get a test name of `MyTest,` and not find a class by that name.

Not sure if creating a test for this makes sense, but I can make one if you should so desire. :)
