### PR TITLE
Support load testng xml file outside the workspace

### DIFF
--- a/src/main/org/testng/eclipse/launch/MultiSelector.java
+++ b/src/main/org/testng/eclipse/launch/MultiSelector.java
@@ -5,17 +5,18 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.collect.Maps;
-
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.SelectionStatusDialog;
 import org.testng.eclipse.launch.TestNGLaunchConfigurationConstants.LaunchType;
 import org.testng.eclipse.launch.components.CheckBoxTable;
 import org.testng.eclipse.util.StringUtils;
+
+import com.google.common.collect.Maps;
 
 /**
  * Abstract base class for launch configurations that allow the user to select one or more
@@ -70,7 +71,7 @@ abstract public class MultiSelector extends TestngTestSelector {
     if (values.size() > 0) {
       String[] uniqueValues = values.toArray(new String[values.size()]);
       Arrays.sort(uniqueValues);
-      final CheckBoxTable cbt = new CheckBoxTable(getCallback().getShell(), uniqueValues, titleId);
+      final CheckBoxTable cbt = getCheckBoxTable(getCallback().getShell(), uniqueValues, titleId);
       String content = getText();
       if(! StringUtils.isEmptyString(content)) {
         List<String> s = StringUtils.stringToList(content);
@@ -88,4 +89,7 @@ abstract public class MultiSelector extends TestngTestSelector {
     }
   }
 
+  protected CheckBoxTable getCheckBoxTable(Shell shell, String[] values, String titleId){
+	    return new CheckBoxTable(getCallback().getShell(), values, titleId);
+	}
 }

--- a/src/main/org/testng/eclipse/launch/SuiteSelector2.java
+++ b/src/main/org/testng/eclipse/launch/SuiteSelector2.java
@@ -6,16 +6,19 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.collect.Lists;
-
 import org.eclipse.core.internal.resources.File;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Shell;
 import org.testng.collections.Maps;
 import org.testng.eclipse.launch.TestNGLaunchConfigurationConstants.LaunchType;
+import org.testng.eclipse.launch.components.CheckBoxTable;
+import org.testng.eclipse.launch.components.SuiteFileCheckBoxTable;
 import org.testng.eclipse.ui.util.ConfigurationHelper;
 import org.testng.eclipse.util.StringUtils;
 import org.testng.eclipse.util.TestSearchEngine;
+
+import com.google.common.collect.Lists;
 
 /**
  * Allow the user to select one or many suite files in this launch configuration.
@@ -47,7 +50,6 @@ public class SuiteSelector2 extends MultiSelector {
     }
 
     return result;
-//    return ConfigurationHelper.getSuites(configuration);
   }
 
   @Override
@@ -65,12 +67,8 @@ public class SuiteSelector2 extends MultiSelector {
     return result;
   }
 
-//  @Override
-//  protected ButtonHandler createButtonHandler() {
-//    return new TestngTestSelector.ButtonHandler() {
-//      public void handleButton() {
-//        getCallback().handleSearchButtonSelected(LaunchType.SUITE);
-//      }
-//    };
-//  }
+  @Override
+  protected CheckBoxTable getCheckBoxTable(Shell shell, String[] values, String titleId){
+    return new SuiteFileCheckBoxTable(getCallback().getShell(), values, titleId);
+  }
 }

--- a/src/main/org/testng/eclipse/launch/components/CheckBoxTable.java
+++ b/src/main/org/testng/eclipse/launch/components/CheckBoxTable.java
@@ -3,8 +3,6 @@ package org.testng.eclipse.launch.components;
 import java.util.Collection;
 import java.util.List;
 
-import com.google.common.collect.Lists;
-
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jdt.internal.ui.dialogs.StatusInfo;
 import org.eclipse.jface.viewers.CheckStateChangedEvent;
@@ -23,6 +21,8 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.ui.dialogs.SelectionStatusDialog;
 import org.testng.eclipse.util.ResourceUtil;
+
+import com.google.common.collect.Lists;
 
 /**
  * A Table with checkboxes to present group names.
@@ -48,6 +48,16 @@ public class CheckBoxTable extends SelectionStatusDialog {
     setTitle(ResourceUtil.getString(titleId));
   }
   
+  protected void removeSelectionElements(){
+    List<Object> toRemove = Lists.newArrayList();
+    for (Object element : m_selection) {
+      if (!m_viewer.setChecked(element.toString(), true)) {
+        toRemove.add(element);
+      }
+    }
+    m_selection.removeAll(toRemove);
+  }
+  
   /**
    * Handles cancel button pressed event.
    */
@@ -66,21 +76,15 @@ public class CheckBoxTable extends SelectionStatusDialog {
   protected CheckboxTableViewer createTableViewer(Composite parent) {
     m_viewer = CheckboxTableViewer.newCheckList(parent, SWT.BORDER);
 
-    m_viewer.setContentProvider(new GroupNamesContentProvider(m_elements));
+    m_viewer.setContentProvider(new GroupNamesContentProvider());
     m_viewer.setLabelProvider(new GroupNameLabelProvider());
 
     m_viewer.setInput(m_elements);
-    List<Object> toRemove = Lists.newArrayList();
-    for (Object element : m_selection) {
-      if (!m_viewer.setChecked(element.toString(), true)) {
-        toRemove.add(element);
-      }
-    }
-    m_selection.removeAll(toRemove);
-
+    removeSelectionElements();
     return m_viewer;
   }
 
+  
   @Override
   protected Control createDialogArea(Composite parent) {
     Composite composite = (Composite) super.createDialogArea(parent);
@@ -135,14 +139,12 @@ public class CheckBoxTable extends SelectionStatusDialog {
   }
   
   private static class GroupNamesContentProvider implements IStructuredContentProvider {
-    private String[] m_groupNames;
     
-    public GroupNamesContentProvider(final String[] groups) {
-      m_groupNames = groups;
-    }
-    
-    public Object[] getElements(Object inputElement) {
-      return m_groupNames;
+    public Object[] getElements(Object inputElement) {      
+      if (inputElement instanceof String[]){
+        return (String[])inputElement;
+      }
+      return null;
     }
 
     public void dispose() {

--- a/src/main/org/testng/eclipse/launch/components/SuiteFileCheckBoxTable.java
+++ b/src/main/org/testng/eclipse/launch/components/SuiteFileCheckBoxTable.java
@@ -1,0 +1,66 @@
+package org.testng.eclipse.launch.components;
+
+import java.util.Collection;
+
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.FileDialog;
+import org.eclipse.swt.widgets.Shell;
+
+/**
+ * Add a file system browser for the current check box table
+ * @author Tim wu
+ *
+ */
+public class SuiteFileCheckBoxTable extends CheckBoxTable {
+
+  private static final String FILE_SYSTEM_LABEL = "File System...";
+  private static final int LABEL_ID = 11111;
+  
+  public SuiteFileCheckBoxTable(Shell shell, Collection<String> elements,
+      String titleId) {
+    super(shell, elements.toArray(new String[elements.size()]), titleId);
+  }
+
+  public SuiteFileCheckBoxTable(Shell shell, String[] elements, String titleId) {
+    super(shell, elements, titleId);
+  }
+
+  protected Control createButtonBar(Composite parent) {
+     super.createButtonBar(parent);
+     //Add a new button at the left corner
+     Composite composite = new Composite(parent, SWT.NULL);
+     GridLayout layout = new GridLayout();
+     layout.numColumns = 1;
+     layout.marginHeight = 0;
+     layout.marginLeft = convertHorizontalDLUsToPixels(IDialogConstants.HORIZONTAL_MARGIN);
+     layout.marginWidth = 0;
+     composite.setLayout(layout);
+     composite.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+     Button btn = createButton(composite, LABEL_ID,
+         FILE_SYSTEM_LABEL, false);
+     btn.addSelectionListener(new SelectionAdapter() {
+     public void widgetSelected(SelectionEvent e) {
+       FileDialog fileselect = new FileDialog(getShell(), SWT.SINGLE);
+       fileselect.setFilterExtensions(new String[] { "*.xml" });
+       String url = fileselect.open();
+       m_viewer.setInput(new String[] { url });
+       m_viewer.setChecked(url, true);
+       //Remove all existing selection element
+       removeSelectionElements();
+       checkElements(new String[] { url });
+       m_viewer.refresh();
+     }
+   });
+
+     return parent;
+  }
+
+}


### PR DESCRIPTION
Currently, TestNG eclipse plugin could only allow user to load the xml/yaml file inside work space, my patch add a new row at launch tab to support users to load the xml/yaml file from file system.
