### PR TITLE
Fix the bug that JAVA assert was enabled defautly

### DIFF
--- a/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationDelegate.java
+++ b/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationDelegate.java
@@ -125,10 +125,8 @@ public class TestNGLaunchConfigurationDelegate extends AbstractJavaLaunchConfigu
     }
 
     // Program & VM args
-    StringBuilder vmArgs = new StringBuilder(ConfigurationHelper.getJvmArgs(configuration))
+    StringBuilder vmArgs = new StringBuilder(ConfigurationHelper.getJvmArgs(configuration));
         // getVMArguments(configuration))
-        .append(" ")
-        .append(TestNGLaunchConfigurationConstants.VM_ENABLEASSERTION_OPTION); // $NON-NLS-1$
     addDebugProperties(vmArgs);
     ExecutionArguments execArgs = new ExecutionArguments(vmArgs.toString(), ""); //$NON-NLS-1$
     String[] envp = DebugPlugin.getDefault().getLaunchManager().getEnvironment(configuration);


### PR DESCRIPTION
TestNG Eclipse plugin enbale JAVA assert by defaultly, however, I think it should be disabled based on JAVA default action.
