### PR TITLE
Changes required to allow building on Eclipse Luna.

### DIFF
--- a/src/main/org/testng/eclipse/ui/QuickRunAction.java
+++ b/src/main/org/testng/eclipse/ui/QuickRunAction.java
@@ -79,7 +79,7 @@ public class QuickRunAction extends Action {
     m_runInfo.setJvmArgs(ConfigurationHelper.getJvmArgs(config));
     try {
       m_runInfo.setEnvironmentVariables(config.getAttribute(
-          ILaunchManager.ATTR_ENVIRONMENT_VARIABLES, (Map<?, ?>) null));
+          ILaunchManager.ATTR_ENVIRONMENT_VARIABLES, (Map<String, String>) null));
     } catch (CoreException e) {
       TestNGPlugin.log(e);
     }

--- a/src/main/org/testng/eclipse/ui/util/ConfigurationHelper.java
+++ b/src/main/org/testng/eclipse/ui/util/ConfigurationHelper.java
@@ -526,14 +526,14 @@ public class ConfigurationHelper {
       }
     }
     Collection<String> classNames= launchInfo.m_classNames;
-    List<Object> classNamesList= new ArrayList<Object>();
+    List<String> classNamesList= new ArrayList<String>();
     if(null != classNames && !classNames.isEmpty()) {
       for (String cls : classNames) {
         classMethods.put(cls, Collections.<String>emptyList());
         classNamesList.add(cls);
       }
     }
-    List<Object> packageList = new ArrayList<Object>();
+    List<String> packageList = new ArrayList<String>();
     if (launchInfo.m_packageNames != null) {
     	packageList.addAll(launchInfo.m_packageNames);
     }    
@@ -552,7 +552,7 @@ public class ConfigurationHelper {
     configuration.setAttribute(TestNGLaunchConfigurationConstants.PACKAGE_TEST_LIST,
     		packageList);
     configuration.setAttribute(TestNGLaunchConfigurationConstants.GROUP_LIST,
-                               new ArrayList<Object>(launchInfo.m_groupMap.keySet()));
+                               new ArrayList<String>(launchInfo.m_groupMap.keySet()));
     configuration.setAttribute(TestNGLaunchConfigurationConstants.GROUP_CLASS_LIST,
                                Utils.uniqueMergeList(launchInfo.m_groupMap.values()));
     configuration.setAttribute(TestNGLaunchConfigurationConstants.SUITE_TEST_LIST,

--- a/src/main/org/testng/eclipse/util/LaunchUtil.java
+++ b/src/main/org/testng/eclipse/util/LaunchUtil.java
@@ -132,8 +132,8 @@ public class LaunchUtil {
         createLaunchConfiguration(project, fileConfName, null);
     try {
       if (prevConfig != null) {
-        Map<?, ?> previousEnv
-            = prevConfig.getAttribute(ILaunchManager.ATTR_ENVIRONMENT_VARIABLES, (Map<?, ?>) null);
+        Map<String, String> previousEnv
+            = prevConfig.getAttribute(ILaunchManager.ATTR_ENVIRONMENT_VARIABLES, (Map<String, String>) null);
         configWC.setAttribute(ILaunchManager.ATTR_ENVIRONMENT_VARIABLES, previousEnv);
       }
     } catch (CoreException e) {
@@ -165,7 +165,7 @@ public class LaunchUtil {
   
   public static void launchMapConfiguration(IProject project,
                                             String configName,
-                                            Map<String, Map> launchAttributes,
+                                            Map<String, Object> launchAttributes,
                                             ICompilationUnit compilationUnit,
                                             String launchMode) {
     ILaunchConfigurationWorkingCopy workingCopy= createLaunchConfiguration(project, configName, null);


### PR DESCRIPTION
Tested by building against both Eclipse Kepler and Eclipse Luna.

Eclipse Luna (4.4) will be released at the end of this month (June 2014.)
