### PR TITLE
Add a preference for the test view taking focus when tests complete

### DIFF
--- a/src/main/org/testng/eclipse/TestNGPluginConstants.java
+++ b/src/main/org/testng/eclipse/TestNGPluginConstants.java
@@ -28,6 +28,7 @@ public abstract class TestNGPluginConstants {
   public static final String S_EXCLUDED_STACK_TRACES = "excludedStackTraces";
   public static final String S_SUITE_METHOD_TREATMENT = "suiteMethodTreatment";
   public static final String S_PRE_DEFINED_LISTENERS = "preDefinedListeners";
+  public static final String S_SHOW_VIEW_WHEN_TESTS_COMPLETE = "showViewWhenTestComplete";
 
   private TestNGPluginConstants() {}
 }

--- a/src/main/org/testng/eclipse/ui/TestRunnerViewPart.java
+++ b/src/main/org/testng/eclipse/ui/TestRunnerViewPart.java
@@ -61,13 +61,11 @@ import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.IMemento;
-import org.eclipse.ui.IPartListener2;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IViewSite;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPart;
-import org.eclipse.ui.IWorkbenchPartReference;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
@@ -508,17 +506,29 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
 
     if(page != null) {
       try {
+        // Only have the view forcibly shown and take focus if the preference is
+        // set to do so, otherwise just make sure the view exists
+        boolean focusOnView = TestNGPlugin.getDefault().getPreferenceStore()
+            .getBoolean(TestNGPluginConstants.S_SHOW_VIEW_WHEN_TESTS_COMPLETE);
+
         testRunner = (TestRunnerViewPart) page.findView(TestRunnerViewPart.NAME);
-        if(testRunner == null) {
 
-          IWorkbenchPart activePart = page.getActivePart();
-          testRunner = (TestRunnerViewPart) page.showView(TestRunnerViewPart.NAME);
+        if (focusOnView) {
+          if (testRunner == null) {
+            IWorkbenchPart activePart = page.getActivePart();
+            testRunner = (TestRunnerViewPart) page
+                .showView(TestRunnerViewPart.NAME);
 
-          //restore focus
-          page.activate(activePart);
-        }
-        else {
-          page.bringToTop(testRunner);
+            // restore focus
+            page.activate(activePart);
+          } else {
+            page.bringToTop(testRunner);
+          }
+        } else {
+          // Make sure the view exists, but don't force it to the front or give
+          // it focus
+          page.showView(TestRunnerViewPart.NAME, null,
+              IWorkbenchPage.VIEW_CREATE);
         }
       }
       catch(PartInitException pie) {

--- a/src/main/org/testng/eclipse/ui/preferences/PreferenceInitializer.java
+++ b/src/main/org/testng/eclipse/ui/preferences/PreferenceInitializer.java
@@ -16,12 +16,17 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
    * @see org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer#
    * initializeDefaultPreferences()
    */
+  @Override
   public void initializeDefaultPreferences() {
     IPreferenceStore store = TestNGPlugin.getDefault().getPreferenceStore();
     store.setDefault(TestNGPluginConstants.S_OUTDIR, "/test-output");
     store.setDefault(TestNGPluginConstants.S_EXCLUDED_STACK_TRACES,
         "org.testng.internal org.testng.TestRunner org.testng.SuiteRunner "
         + "org.testng.remote.RemoteTestNG org.testng.TestNG sun.reflect java.lang");
+    // Set the default to the original behavior, where the view takes focus when
+    // tests finish running
+    store.setDefault(TestNGPluginConstants.S_SHOW_VIEW_WHEN_TESTS_COMPLETE,
+        true);
   }
 
 }

--- a/src/main/org/testng/eclipse/ui/preferences/WorkspacePreferencePage.java
+++ b/src/main/org/testng/eclipse/ui/preferences/WorkspacePreferencePage.java
@@ -1,6 +1,8 @@
 package org.testng.eclipse.ui.preferences;
 
 
+import java.io.File;
+
 import org.eclipse.debug.internal.ui.preferences.BooleanFieldEditor2;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.preference.DirectoryFieldEditor;
@@ -18,8 +20,6 @@ import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.testng.eclipse.TestNGPlugin;
 import org.testng.eclipse.TestNGPluginConstants;
 
-import java.io.File;
-
 /**
  * Workspace wide preferences for TestNG.
  */
@@ -30,6 +30,7 @@ public class WorkspacePreferencePage
   private FSBrowseDirectoryFieldEditor m_outputdir;
   private BooleanFieldEditor2 m_absolutePath;
   private BooleanFieldEditor2 m_disabledDefaultListeners;
+  private BooleanFieldEditor2 m_showViewWhenTestsComplete;
   private FileFieldEditor m_xmlTemplateFile;
   private StringFieldEditor m_excludedStackTraces;
   private StringFieldEditor m_preDefinedListeners;
@@ -72,6 +73,11 @@ public class WorkspacePreferencePage
         SWT.NONE, 
         parentComposite);
 
+    m_showViewWhenTestsComplete = new BooleanFieldEditor2(
+        TestNGPluginConstants.S_SHOW_VIEW_WHEN_TESTS_COMPLETE,
+        "Show view when tests complete", //$NON-NLS-1$ 
+        SWT.NONE, parentComposite);
+
     // XML template
     m_xmlTemplateFile = new FileFieldEditor(TestNGPluginConstants.S_XML_TEMPLATE_FILE,
         "Template XML file:", false /* no absolute */,
@@ -93,7 +99,8 @@ public class WorkspacePreferencePage
 
     addField(m_outputdir);
     addField(m_absolutePath);
-    addField(m_disabledDefaultListeners);    
+    addField(m_disabledDefaultListeners);
+    addField(m_showViewWhenTestsComplete);
     addField(m_xmlTemplateFile);
     addField(m_excludedStackTraces);
     addField(m_preDefinedListeners);


### PR DESCRIPTION
I use TestNG a lot with personal projects and in my job, and it is wonderful. One of the few things that makes it more difficult to work with in Eclipse is that the test result window jumps to the top of its pane once a test run completes, overlaying whatever I had been working on while waiting for the tests to complete (or the console I was watching while the tests ran). The standard console has a preference to disable this behavior, and it would make the plug-in integrate much better with how I use Eclipse if it also presented such an option.

I've put together a pull request which makes this behavior a configurable preference (which defaults to the current behavior). It allows the default "focus on test complete" to be turned off, similar to how the built-in console can have its "show on stdout" and "show on stderr" behaviors configured.

I didn't see any specific guidelines for pull requests in the readme, so I just tried to match the existing coding conventions. I manually tested the change - I'm not sure how to unit test Eclipse plug-in UI elements

![testngpref](https://cloud.githubusercontent.com/assets/1018131/5195720/3b46c4e2-74ef-11e4-9a36-c2434cd0560b.png)

Thanks for the great work on TestNG overall, its been a very valuable tool!
