### PR TITLE
Add pattern filter for suite selector

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.testng.eclipse; singleton:=true
-Bundle-Version: 6.8.1.20130330_0839
+Bundle-Version: 6.8.6.qualifier
 Bundle-Activator: org.testng.eclipse.TestNGPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/src/main/org/testng/eclipse/launch/SuiteSelector2.java
+++ b/src/main/org/testng/eclipse/launch/SuiteSelector2.java
@@ -30,7 +30,8 @@ public class SuiteSelector2 extends MultiSelector {
   SuiteSelector2(TestNGMainTab callback, Composite comp) {
     super(callback, comp, LaunchType.SUITE, "TestNGMainTab.label.suiteTest",
         "CheckBoxTable.suites.title");
-    setTextEditable(true); // no manual edit
+    // make it editable to be able to modify the order easier
+    setTextEditable(true);
   }
 
   @Override

--- a/src/main/org/testng/eclipse/launch/SuiteSelector2.java
+++ b/src/main/org/testng/eclipse/launch/SuiteSelector2.java
@@ -30,7 +30,7 @@ public class SuiteSelector2 extends MultiSelector {
   SuiteSelector2(TestNGMainTab callback, Composite comp) {
     super(callback, comp, LaunchType.SUITE, "TestNGMainTab.label.suiteTest",
         "CheckBoxTable.suites.title");
-    setTextEditable(false); // no manual edit
+    setTextEditable(true); // no manual edit
   }
 
   @Override

--- a/testng-eclipse-feature/feature.xml
+++ b/testng-eclipse-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.testng.eclipse"
       label="TestNG"
-      version="6.1.1.20110823_1537"
+      version="6.8.6.qualifier"
       provider-name="Cedric Beust">
 
    <description url="http://testng.org">

--- a/testng-eclipse-update-site/site.xml
+++ b/testng-eclipse-update-site/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/org.testng.eclipse_6.1.1.20110823_1537.jar" id="org.testng.eclipse" version="6.1.1.20110823_1537">
+   <feature url="features/org.testng.eclipse_6.8.6.qualifier.jar" id="org.testng.eclipse" version="6.8.6.qualifier">
       <category name="org.testng.eclipse"/>
    </feature>
    <category-def name="org.testng.eclipse" label="TestNG"/>


### PR DESCRIPTION
Hi
as we have a lot of testng xml suite which caused a quite long list in the suite selector dialog, so i add a pattern filter text so that we can quickly filter out the expected suites name