### PR TITLE
Add support for preserve-order parameter taken from template suite

### DIFF
--- a/src/main/org/testng/eclipse/util/CustomSuite.java
+++ b/src/main/org/testng/eclipse/util/CustomSuite.java
@@ -170,6 +170,7 @@ abstract public class CustomSuite extends LaunchSuite {
         put(attr, "data-provider-thread-count", s.getDataProviderThreadCount());
         put(attr, "object-factory", s.getObjectFactory());
         put(attr, "allow-return-values", s.getAllowReturnValues());
+        put(attr, "preserve-order", s.getPreserveOrder());
         suiteBuffer.push("suite", attr);
 
         // Children of <suite>


### PR DESCRIPTION
As you can define preserve-order parameter also on suite, add this possibility to CustomSuite creation from defined template suite.