### PR TITLE
Fix #136: change feature id back to 'org.testng.eclipse' to make eclipse update manager work

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.testng.eclipse</groupId>
     <artifactId>org.testng.eclipse.parent</artifactId>
-    <version>6.8.22.2015_05_03_1820</version>
+    <version>6.8.22-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/testng-eclipse-feature/feature.xml
+++ b/testng-eclipse-feature/feature.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
-      id="org.testng.eclipse.feature"
+      id="org.testng.eclipse"
       label="TestNG"
-      version="6.8.22.2015_05_03_1820"
+      version="6.8.22.qualifier"
       provider-name="Cedric Beust">
 
    <description url="http://testng.org">

--- a/testng-eclipse-feature/pom.xml
+++ b/testng-eclipse-feature/pom.xml
@@ -6,9 +6,10 @@
     <parent>
         <groupId>org.testng.eclipse</groupId>
         <artifactId>org.testng.eclipse.parent</artifactId>
-        <version>6.8.22.2015_05_03_1820</version>
+        <version>6.8.22-SNAPSHOT</version>
     </parent>
-    <artifactId>org.testng.eclipse.feature</artifactId>
+    <groupId>org.testng.eclipse.features</groupId>
+    <artifactId>org.testng.eclipse</artifactId>
     <packaging>eclipse-feature</packaging>
 
 </project>

--- a/testng-eclipse-plugin/META-INF/MANIFEST.MF
+++ b/testng-eclipse-plugin/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.testng.eclipse; singleton:=true
-Bundle-Version: 6.8.22.2015_05_03_1820
+Bundle-Version: 6.8.22.qualifier
 Bundle-Activator: org.testng.eclipse.TestNGPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/testng-eclipse-plugin/pom.xml
+++ b/testng-eclipse-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.testng.eclipse</groupId>
         <artifactId>org.testng.eclipse.parent</artifactId>
-        <version>6.8.22.2015_05_03_1820</version>
+        <version>6.8.22-SNAPSHOT</version>
     </parent>
     <artifactId>org.testng.eclipse</artifactId>
     <packaging>eclipse-plugin</packaging>

--- a/testng-eclipse-update-site/pom.xml
+++ b/testng-eclipse-update-site/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.testng.eclipse</groupId>
         <artifactId>org.testng.eclipse.parent</artifactId>
-        <version>6.8.22.2015_05_03_1820</version>
+        <version>6.8.22-SNAPSHOT</version>
     </parent>
   <artifactId>org.testng.eclipse.updatesite</artifactId>
   <packaging>eclipse-update-site</packaging>

--- a/testng-eclipse-update-site/site.xml
+++ b/testng-eclipse-update-site/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/org.testng.eclipse.feature_6.8.22.2015_05_03_1820.jar" id="org.testng.eclipse.feature" version="6.8.22.2015_05_03_1820">
+   <feature url="features/org.testng.eclipse_6.8.22.qualifier.jar" id="org.testng.eclipse" version="6.8.22.qualifier">
       <category name="org.testng.eclipse"/>
    </feature>
    <category-def name="org.testng.eclipse" label="TestNG"/>


### PR DESCRIPTION
As PR #135 changed the feature ID cause the eclipse update manager does not recognize new update since 6.8.22.xxx. 
As the feature Id must be same as the artifactId of the pom, the original group/artfactId layout was:
```
org.testng.eclipse.parent
    org.testng.eclipse
        org.testng.eclipse     # the artifactId of the plugin
        org.testng.eclipse.feature       # the artifactId of the feature
```

now changed as:
```
org.testng.eclipse.parent
    org.testng.eclipse         # the groupId for the plugins
        org.testng.eclipse     # the artifactId of the plugin
    org.testng.eclipse.feature       # the groupId for the features
        org.testng.eclipse     # the artifactId of the feature
```

now the generated update-site with featureId back to the old way