### PR TITLE
Added "group-by-instances" attribute in createXmlFileFromTemplate()

### DIFF
--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/util/CustomSuite.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/util/CustomSuite.java
@@ -171,6 +171,7 @@ abstract public class CustomSuite extends LaunchSuite {
         put(attr, "object-factory", s.getObjectFactory());
         put(attr, "allow-return-values", s.getAllowReturnValues());
         put(attr, "preserve-order", s.getPreserveOrder());
+        put(attr, "group-by-instances", s.getGroupByInstances());
         suiteBuffer.push("suite", attr);
 
         // Children of <suite>


### PR DESCRIPTION
The attribute "group-by-instances" was being ignored. I added this attribute to correctly generate the XML file.