### PR TITLE
issue-149: check the minimum java version for runing testng

### DIFF
--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGMessages.properties
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGMessages.properties
@@ -41,7 +41,7 @@ TestNGMainTab.error.methodnotdefined=Method not specified
 
 TestNGLaunchConfigurationDelegate.error.invalidproject=Invalid project
 TestNGLaunchConfigurationDelegate.error.novmrunner=No runtime VM runner for VM Install {0}
-TestNGLaunchConfigurationDelegate.error.incompatiblevmversion=VM version {0} is invalid, Jave 1.7 or above is required for running TestNG.
+TestNGLaunchConfigurationDelegate.error.incompatiblevmversion=VM version {0} is invalid, Java 1.7 or above is required for running TestNG.
 
 CounterPanel.label.passed=Passed
 CounterPanel.label.failed=Failed

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGMessages.properties
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGMessages.properties
@@ -40,6 +40,8 @@ TestNGMainTab.error.packagenotdefined=Package not specified
 TestNGMainTab.error.methodnotdefined=Method not specified
 
 TestNGLaunchConfigurationDelegate.error.invalidproject=Invalid project
+TestNGLaunchConfigurationDelegate.error.novmrunner=No runtime VM runner for VM Install {0}
+TestNGLaunchConfigurationDelegate.error.incompatiblevmversion=VM version {0} is invalid, Jave 1.7 or above is required for running TestNG.
 
 CounterPanel.label.passed=Passed
 CounterPanel.label.failed=Failed

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGPluginConstants.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGPluginConstants.java
@@ -7,6 +7,8 @@ import org.testng.remote.RemoteTestNG;
  */
 public abstract class TestNGPluginConstants {
   public static final int LAUNCH_ERROR = 1001;
+  public static final int LAUNCH_ERROR_JVM_VER_NOT_COMPATIBLE = 1002;
+
   public static final String TESTNG_HOME= "TESTNG_HOME"; //$NON-NLS-1$
   public static final String MAIN_RUNNER = RemoteTestNG.class.getName();
   

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationDelegate.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationDelegate.java
@@ -18,6 +18,7 @@ import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.launching.AbstractJavaLaunchConfigurationDelegate;
+import org.eclipse.jdt.launching.AbstractVMInstall;
 import org.eclipse.jdt.launching.ExecutionArguments;
 import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
 import org.eclipse.jdt.launching.IVMInstall;
@@ -27,6 +28,7 @@ import org.eclipse.jdt.launching.VMRunnerConfiguration;
 import org.testng.CommandLineArgs;
 import org.testng.ITestNGListener;
 import org.testng.eclipse.TestNGPlugin;
+import org.testng.eclipse.TestNGPluginConstants;
 import org.testng.eclipse.buildpath.BuildPathSupport;
 import org.testng.eclipse.launch.TestNGLaunchConfigurationConstants.LaunchType;
 import org.testng.eclipse.ui.util.ConfigurationHelper;
@@ -58,6 +60,13 @@ public class TestNGLaunchConfigurationDelegate extends AbstractJavaLaunchConfigu
       abort(ResourceUtil.getFormattedString("TestNGLaunchConfigurationDelegate.error.novmrunner", //$NON-NLS-1$
           new String[] { install.getId() }), null,
           IJavaLaunchConfigurationConstants.ERR_VM_RUNNER_DOES_NOT_EXIST);
+    }
+    AbstractVMInstall vmi = (AbstractVMInstall) install;
+    String vmver = vmi.getJavaVersion();
+    if (vmver.compareTo("1.7") < 0) { //$NON-NLS-1$
+      abort(ResourceUtil.getFormattedString("TestNGLaunchConfigurationDelegate.error.incompatiblevmversion", //$NON-NLS-1$
+          new String[] { vmver }), null,
+          TestNGPluginConstants.LAUNCH_ERROR_JVM_VER_NOT_COMPATIBLE);
     }
 
     int port = SocketUtil.findFreePort();


### PR DESCRIPTION
this PR is to fix #149 by checking the minimum java version before launching testng