### PR TITLE
Issue/149 better way to compare the java version compatibility

### DIFF
--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationDelegate.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationDelegate.java
@@ -10,8 +10,6 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
@@ -125,7 +123,6 @@ public class TestNGLaunchConfigurationDelegate extends AbstractJavaLaunchConfigu
     }
   }
 
-  @SuppressWarnings("unchecked")
   protected VMRunnerConfiguration launchTypes(final ILaunchConfiguration configuration,
       ILaunch launch, final IJavaProject jproject, final int port, final String mode)
       throws CoreException {
@@ -150,7 +147,7 @@ public class TestNGLaunchConfigurationDelegate extends AbstractJavaLaunchConfigu
     runConfig.setWorkingDirectory(workingDirName);
     runConfig.setEnvironment(envp);
 
-    Map vmAttributesMap = getVMSpecificAttributesMap(configuration);
+    Map<String, Object> vmAttributesMap = getVMSpecificAttributesMap(configuration);
     runConfig.setVMSpecificAttributesMap(vmAttributesMap);
 
     String[] bootpath = getBootpath(configuration);
@@ -357,8 +354,4 @@ public class TestNGLaunchConfigurationDelegate extends AbstractJavaLaunchConfigu
     }
   }
 
-  private static void ppp(final Object msg) {
-    TestNGPlugin
-        .log(new Status(IStatus.INFO, TestNGPlugin.PLUGIN_ID, 1, String.valueOf(msg), null));
-  }
 }

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationDelegate.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationDelegate.java
@@ -25,6 +25,7 @@ import org.eclipse.jdt.launching.IVMInstall;
 import org.eclipse.jdt.launching.IVMRunner;
 import org.eclipse.jdt.launching.SocketUtil;
 import org.eclipse.jdt.launching.VMRunnerConfiguration;
+import org.osgi.framework.Version;
 import org.testng.CommandLineArgs;
 import org.testng.ITestNGListener;
 import org.testng.eclipse.TestNGPlugin;
@@ -62,10 +63,11 @@ public class TestNGLaunchConfigurationDelegate extends AbstractJavaLaunchConfigu
           IJavaLaunchConfigurationConstants.ERR_VM_RUNNER_DOES_NOT_EXIST);
     }
     AbstractVMInstall vmi = (AbstractVMInstall) install;
-    String vmver = vmi.getJavaVersion();
-    if (vmver.compareTo("1.7") < 0) { //$NON-NLS-1$
+    Version vmVer = new Version(vmi.getJavaVersion());
+    Version mimVer = new Version("1.7.0"); //$NON-NLS-1$
+    if (vmVer.compareTo(mimVer) < 0) {
       abort(ResourceUtil.getFormattedString("TestNGLaunchConfigurationDelegate.error.incompatiblevmversion", //$NON-NLS-1$
-          new String[] { vmver }), null,
+          new String[] { vmi.getJavaVersion() }), null,
           TestNGPluginConstants.LAUNCH_ERROR_JVM_VER_NOT_COMPATIBLE);
     }
 


### PR DESCRIPTION
use org.osgi.framework.Version.compareTo() to compare the java version compatibility rather than String.compareTo()