### PR TITLE
Issue/91 add 'serialization protocol' switch on launch configuration page

### DIFF
--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGMessages.properties
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGMessages.properties
@@ -29,6 +29,8 @@ TestNGMainTab.projectdialog.message=Choose a project to constrain the search for
 TestNGMainTab.runtime.type=Runtime
 TestNGMainTab.testng.compliance=Annotations compliance level (test sources needed for JDK 1.4) 
 TestNGMainTab.testng.loglevel=Log level (0-10)
+TestNGMainTab.testng.verbose=Verbose
+TestNGMainTab.testng.debug=Debug
 
 TestNGMainTab.error.projectnotdefined=Project not specified
 TestNGMainTab.error.projectnotexists=Project {0} does not exist

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGMessages.properties
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGMessages.properties
@@ -31,6 +31,9 @@ TestNGMainTab.testng.compliance=Annotations compliance level (test sources neede
 TestNGMainTab.testng.loglevel=Log level (0-10)
 TestNGMainTab.testng.verbose=Verbose
 TestNGMainTab.testng.debug=Debug
+TestNGMainTab.testng.protocol=Serilization Protocol
+TestNGMainTab.testng.protocol.object=Object Serialization
+TestNGMainTab.testng.protocol.string=String Serialization (Deprecated)
 
 TestNGMainTab.error.projectnotdefined=Project not specified
 TestNGMainTab.error.projectnotexists=Project {0} does not exist

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationConstants.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationConstants.java
@@ -94,6 +94,8 @@ public abstract class TestNGLaunchConfigurationConstants {
   
   public static final String DEBUG = make("DEBUG");  //$NON-NLS-1$
   
+  public static final String PROTOCOL = make("PROTOCOL");  //$NON-NLS-1$
+  
 //  public static final String TESTNG_COMPLIANCE_LEVEL_ATTR = make("COMPLIANCE_LEVEL"); //$NON-NLS-1$
   
   public static final String VM_ENABLEASSERTION_OPTION = "-ea";
@@ -127,5 +129,38 @@ public abstract class TestNGLaunchConfigurationConstants {
 
   public static final String PARAMS = make("PARAMETERS");
   
-  
+  public static final Protocols[] SERIALIZATION_PROTOCOLS = {Protocols.OBJECT, Protocols.STRING};
+  public static final Protocols DEFAULT_SERIALIZATION_PROTOCOL = SERIALIZATION_PROTOCOLS[0];
+
+  public static enum Protocols {
+    OBJECT("object"),
+    STRING("string");
+    
+    private final String text;
+
+    /**
+     * @param text
+     */
+    private Protocols(final String text) {
+        this.text = text;
+    }
+    
+    public static Protocols get(String text) {
+      switch (text) {
+      case "object":
+        return OBJECT;
+      case "string":
+        return STRING;
+      default:
+        throw new IllegalArgumentException("Unrecognized protocol: " + text);
+      }
+    }
+
+    @Override
+    public String toString() {
+        return text;
+    }
+  }
+
 }
+

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationConstants.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationConstants.java
@@ -90,6 +90,10 @@ public abstract class TestNGLaunchConfigurationConstants {
   
   public static final String LOG_LEVEL = make("LOG_LEVEL");  //$NON-NLS-1$ 
   
+  public static final String VERBOSE = make("VERBOSE");  //$NON-NLS-1$
+  
+  public static final String DEBUG = make("DEBUG");  //$NON-NLS-1$
+  
 //  public static final String TESTNG_COMPLIANCE_LEVEL_ATTR = make("COMPLIANCE_LEVEL"); //$NON-NLS-1$
   
   public static final String VM_ENABLEASSERTION_OPTION = "-ea";

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationDelegate.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationDelegate.java
@@ -138,6 +138,13 @@ public class TestNGLaunchConfigurationDelegate extends AbstractJavaLaunchConfigu
         .append(" ")
         .append(TestNGLaunchConfigurationConstants.VM_ENABLEASSERTION_OPTION); // $NON-NLS-1$
     addDebugProperties(vmArgs, configuration);
+    switch (ConfigurationHelper.getProtocol(configuration)) {
+    case STRING:
+      vmArgs.append(" -Dtestng.eclipse.stringprotocol");
+      break;
+    default:
+      break;
+    }
     ExecutionArguments execArgs = new ExecutionArguments(vmArgs.toString(), ""); //$NON-NLS-1$
     String[] envp = DebugPlugin.getDefault().getLaunchManager().getEnvironment(configuration);
 

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationDelegate.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationDelegate.java
@@ -135,10 +135,9 @@ public class TestNGLaunchConfigurationDelegate extends AbstractJavaLaunchConfigu
 
     // Program & VM args
     StringBuilder vmArgs = new StringBuilder(ConfigurationHelper.getJvmArgs(configuration))
-        // getVMArguments(configuration))
         .append(" ")
         .append(TestNGLaunchConfigurationConstants.VM_ENABLEASSERTION_OPTION); // $NON-NLS-1$
-    addDebugProperties(vmArgs);
+    addDebugProperties(vmArgs, configuration);
     ExecutionArguments execArgs = new ExecutionArguments(vmArgs.toString(), ""); //$NON-NLS-1$
     String[] envp = DebugPlugin.getDefault().getLaunchManager().getEnvironment(configuration);
 
@@ -159,7 +158,7 @@ public class TestNGLaunchConfigurationDelegate extends AbstractJavaLaunchConfigu
   /**
    * Pass the system properties we were called with to the RemoteTestNG process.
    */
-  private void addDebugProperties(StringBuilder vmArgs) {
+  private void addDebugProperties(StringBuilder vmArgs, ILaunchConfiguration config) {
     String[] debugProperties = new String[] {
         RemoteTestNG.PROPERTY_DEBUG,
         RemoteTestNG.PROPERTY_VERBOSE
@@ -168,6 +167,13 @@ public class TestNGLaunchConfigurationDelegate extends AbstractJavaLaunchConfigu
       if (System.getProperty(p) != null) {
         vmArgs.append(" -D").append(p);
       }
+    }
+
+    if (ConfigurationHelper.getVerbose(config)) {
+      vmArgs.append(" -D" + RemoteTestNG.PROPERTY_VERBOSE);
+    }
+    if (ConfigurationHelper.getDebug(config)) {
+      vmArgs.append(" -D" + RemoteTestNG.PROPERTY_DEBUG);
     }
   }
 

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGMainTab.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGMainTab.java
@@ -17,6 +17,7 @@ import org.eclipse.debug.ui.ILaunchConfigurationTab;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
@@ -24,6 +25,7 @@ import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -81,6 +83,10 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
 
   // Runtime group
   private Combo m_logLevelCombo;
+
+  private Button m_verboseBtn;
+
+  private Button m_debugBtn;
 
   private List <TestngTestSelector> m_launchSelectors = Lists.newArrayList();
   private Map<String, List<String>> m_classMethods;
@@ -201,6 +207,10 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
     int logLevel = ConfigurationHelper.getLogLevel(configuration);
     m_logLevelCombo.select(logLevel);
 
+    m_verboseBtn.setSelection(ConfigurationHelper.getVerbose(configuration));
+
+    m_debugBtn.setSelection(ConfigurationHelper.getDebug(configuration));
+
     LaunchType type = ConfigurationHelper.getType(configuration);
     setType(type);
     m_classMethods = ConfigurationHelper.getClassMethods(configuration);
@@ -241,7 +251,9 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
               m_groupSelector.getValueMap(),
               m_suiteSelector.getText(),
               TestNGLaunchConfigurationConstants.JDK15_COMPLIANCE, 
-              m_logLevelCombo.getText()));
+              m_logLevelCombo.getText(),
+              m_verboseBtn.getSelection(),
+              m_debugBtn.getSelection()));
   }
 
   /**
@@ -468,6 +480,31 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
         }
       });
     }
+
+    m_verboseBtn = new Button(group, SWT.CHECK);
+    m_verboseBtn.setText(ResourceUtil.getString("TestNGMainTab.testng.verbose"));
+    GridDataFactory.fillDefaults().span(3, SWT.None).applyTo(m_verboseBtn);
+    m_verboseBtn.addSelectionListener(new SelectionListener() {
+      public void widgetSelected(SelectionEvent e) {
+        updateLaunchConfigurationDialog();
+      }
+
+      public void widgetDefaultSelected(SelectionEvent e) {
+      }
+    });
+
+    m_debugBtn = new Button(group, SWT.CHECK);
+    m_debugBtn.setText(ResourceUtil.getString("TestNGMainTab.testng.debug"));
+    GridDataFactory.fillDefaults().span(3, SWT.None).applyTo(m_debugBtn);
+    m_debugBtn.addSelectionListener(new SelectionListener() {
+      public void widgetSelected(SelectionEvent e) {
+        updateLaunchConfigurationDialog();
+      }
+
+      public void widgetDefaultSelected(SelectionEvent e) {
+      }
+    });
+
   }
 
   private void createProjectSelectionGroup(Composite comp) {

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGMainTab.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGMainTab.java
@@ -18,7 +18,12 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.layout.GridDataFactory;
-import org.eclipse.jface.resource.ImageRegistry;
+import org.eclipse.jface.viewers.ArrayContentProvider;
+import org.eclipse.jface.viewers.ComboViewer;
+import org.eclipse.jface.viewers.ISelectionChangedListener;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.SelectionChangedEvent;
+import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyEvent;
@@ -40,6 +45,7 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.SelectionDialog;
 import org.testng.eclipse.TestNGPlugin;
 import org.testng.eclipse.launch.TestNGLaunchConfigurationConstants.LaunchType;
+import org.testng.eclipse.launch.TestNGLaunchConfigurationConstants.Protocols;
 import org.testng.eclipse.launch.components.Filters;
 import org.testng.eclipse.ui.Images;
 import org.testng.eclipse.ui.util.ConfigurationHelper;
@@ -58,7 +64,6 @@ import org.testng.eclipse.util.TestSearchEngine;
  */
 public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILaunchConfigurationTab
 {
-  private static ImageRegistry m_imageRegistry = null;
   private static final String UNKNOWN_CONSTANT = "Unknown TestNGLaunchConfigurationConstants: ";
 
   private Text m_projectText;
@@ -87,6 +92,8 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
   private Button m_verboseBtn;
 
   private Button m_debugBtn;
+
+  private ComboViewer m_protocolComboViewer;
 
   private List <TestngTestSelector> m_launchSelectors = Lists.newArrayList();
   private Map<String, List<String>> m_classMethods;
@@ -211,6 +218,8 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
 
     m_debugBtn.setSelection(ConfigurationHelper.getDebug(configuration));
 
+    m_protocolComboViewer.setSelection(new StructuredSelection(ConfigurationHelper.getProtocol(configuration)));
+
     LaunchType type = ConfigurationHelper.getType(configuration);
     setType(type);
     m_classMethods = ConfigurationHelper.getClassMethods(configuration);
@@ -253,7 +262,8 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
               TestNGLaunchConfigurationConstants.JDK15_COMPLIANCE, 
               m_logLevelCombo.getText(),
               m_verboseBtn.getSelection(),
-              m_debugBtn.getSelection()));
+              m_debugBtn.getSelection(),
+              (Protocols) ((StructuredSelection) m_protocolComboViewer.getSelection()).getFirstElement()));
   }
 
   /**
@@ -505,6 +515,26 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
       }
     });
 
+
+    Label label = new Label(group, SWT.NONE);
+    label.setText(ResourceUtil.getString("TestNGMainTab.testng.protocol"));
+
+    m_protocolComboViewer = new ComboViewer(group, SWT.READ_ONLY);
+    GridDataFactory.fillDefaults().span(2, SWT.None).applyTo(m_protocolComboViewer.getCombo());
+    m_protocolComboViewer.addSelectionChangedListener(new ISelectionChangedListener() {
+      @Override
+      public void selectionChanged(SelectionChangedEvent event) {
+        updateLaunchConfigurationDialog();
+      }
+    });
+    m_protocolComboViewer.setContentProvider(ArrayContentProvider.getInstance());
+    m_protocolComboViewer.setLabelProvider(new LabelProvider() {
+      @Override
+      public String getText(Object element) {
+        return ResourceUtil.getString("TestNGMainTab.testng.protocol." + element);
+      }
+    });
+    m_protocolComboViewer.setInput(TestNGLaunchConfigurationConstants.SERIALIZATION_PROTOCOLS);
   }
 
   private void createProjectSelectionGroup(Composite comp) {

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/util/ConfigurationHelper.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/util/ConfigurationHelper.java
@@ -50,6 +50,8 @@ public class ConfigurationHelper {
     private Map<String, List<String>> m_groupMap = Maps.newHashMap();
     private String m_complianceLevel;
     private String m_logLevel;
+    private boolean m_verbose;
+    private boolean m_debug;
     
     public LaunchInfo(String projectName,
                       LaunchType launchType,
@@ -59,7 +61,9 @@ public class ConfigurationHelper {
                       Map<String, List<String>> groupMap,
                       String suiteName,
                       String complianceLevel,
-                      String logLevel) {
+                      String logLevel,
+                      boolean verbose, 
+                      boolean debug) {
       m_projectName= projectName;
       m_launchType= launchType;
       m_classNames= classNames;
@@ -69,6 +73,8 @@ public class ConfigurationHelper {
       m_complianceLevel= complianceLevel;
       m_logLevel= logLevel;
       m_packageNames = packageNames;
+      m_verbose = verbose;
+      m_debug = debug;
     }
   }
 
@@ -82,6 +88,14 @@ public class ConfigurationHelper {
     }
   }
   
+  public static boolean getVerbose(ILaunchConfiguration config) {
+    return getBooleanAttribute(config, TestNGLaunchConfigurationConstants.VERBOSE);
+  }
+
+  public static boolean getDebug(ILaunchConfiguration config) {
+    return getBooleanAttribute(config, TestNGLaunchConfigurationConstants.DEBUG);
+  }
+
   public static String getSourcePath(ILaunchConfiguration config) {
     return getStringAttribute(config, TestNGLaunchConfigurationConstants.DIRECTORY_TEST_LIST);
   }
@@ -155,7 +169,7 @@ public class ConfigurationHelper {
   			    result);
   			result = VariablesPlugin.getDefault().getStringVariableManager().performStringSubstitution(result);
   		} catch (CoreException e) {
-  			e.printStackTrace();
+  			TestNGPlugin.log(e);
   		}
     }
 
@@ -236,6 +250,19 @@ public class ConfigurationHelper {
 
   private static int getIntAttribute(ILaunchConfiguration config, String attr) {
     int result = 0;
+    
+    try {
+      result = config.getAttribute(attr, result);
+    }
+    catch (CoreException e) {
+      TestNGPlugin.log(e);
+    }
+    
+    return result;
+  }
+
+  private static boolean getBooleanAttribute(ILaunchConfiguration config, String attr) {
+    boolean result = false;
     
     try {
       result = config.getAttribute(attr, result);
@@ -563,6 +590,7 @@ public class ConfigurationHelper {
 //                               launchInfo.m_complianceLevel);
     configuration.setAttribute(TestNGLaunchConfigurationConstants.LOG_LEVEL,
                                launchInfo.m_logLevel);
-    
+    configuration.setAttribute(TestNGLaunchConfigurationConstants.VERBOSE, launchInfo.m_verbose);
+    configuration.setAttribute(TestNGLaunchConfigurationConstants.DEBUG, launchInfo.m_debug);
   }
 }

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/util/ConfigurationHelper.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/util/ConfigurationHelper.java
@@ -27,6 +27,7 @@ import org.testng.eclipse.TestNGPlugin;
 import org.testng.eclipse.TestNGPluginConstants;
 import org.testng.eclipse.launch.TestNGLaunchConfigurationConstants;
 import org.testng.eclipse.launch.TestNGLaunchConfigurationConstants.LaunchType;
+import org.testng.eclipse.launch.TestNGLaunchConfigurationConstants.Protocols;
 import org.testng.eclipse.ui.RunInfo;
 import org.testng.eclipse.util.StringUtils;
 import org.testng.eclipse.util.SuiteGenerator;
@@ -52,7 +53,8 @@ public class ConfigurationHelper {
     private String m_logLevel;
     private boolean m_verbose;
     private boolean m_debug;
-    
+    private Protocols m_protocol;
+
     public LaunchInfo(String projectName,
                       LaunchType launchType,
                       Collection<String> classNames,
@@ -63,7 +65,8 @@ public class ConfigurationHelper {
                       String complianceLevel,
                       String logLevel,
                       boolean verbose, 
-                      boolean debug) {
+                      boolean debug,
+                      Protocols protocol) {
       m_projectName= projectName;
       m_launchType= launchType;
       m_classNames= classNames;
@@ -75,6 +78,7 @@ public class ConfigurationHelper {
       m_packageNames = packageNames;
       m_verbose = verbose;
       m_debug = debug;
+      m_protocol = protocol;
     }
   }
 
@@ -94,6 +98,11 @@ public class ConfigurationHelper {
 
   public static boolean getDebug(ILaunchConfiguration config) {
     return getBooleanAttribute(config, TestNGLaunchConfigurationConstants.DEBUG);
+  }
+
+  public static Protocols getProtocol(ILaunchConfiguration config) {
+    String stringResult = getStringAttribute(config, TestNGLaunchConfigurationConstants.PROTOCOL);
+    return null == stringResult ? TestNGLaunchConfigurationConstants.DEFAULT_SERIALIZATION_PROTOCOL : Protocols.get(stringResult); 
   }
 
   public static String getSourcePath(ILaunchConfiguration config) {
@@ -592,5 +601,6 @@ public class ConfigurationHelper {
                                launchInfo.m_logLevel);
     configuration.setAttribute(TestNGLaunchConfigurationConstants.VERBOSE, launchInfo.m_verbose);
     configuration.setAttribute(TestNGLaunchConfigurationConstants.DEBUG, launchInfo.m_debug);
+    configuration.setAttribute(TestNGLaunchConfigurationConstants.PROTOCOL, launchInfo.m_protocol.toString());
   }
 }


### PR DESCRIPTION
as the first step, here i added the 'serialization protocol' switch on launch configuration page so that user can easily switch the protocol. in my limited test, the *String Protocol* just works, so this might helpful for people to bypass issue #91 
in fact, i encounter same issue as #91 before, update the JDK version to 7 or use *String Protocol* works for me, so I'd like to share this patch for others.
![screen](http://s30.postimg.org/m3jgk0lyp/Screen_Shot_2015_08_03_at_9_06_21_AM.png)

i definitely need investigate this issue for more time, though for now, i do think it's caused by JDK Object serialization. if so, we might need to implement a new JSON protocol rather than the deprecated String protocol.