### PR TITLE
Issue/91fix Travis-CI build failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
                 <artifactId>tycho-compiler-plugin</artifactId>
                 <version>${tycho.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                     <encoding>UTF-8</encoding>
                     <!-- http://dev.eclipse.org/mhonarc/lists/tycho-user/msg02782.html -->
                     <!-- http://stackoverflow.com/a/28812963 -->

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <tycho.version>0.22.0</tycho.version>
+        <tycho.version>0.23.0</tycho.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
update tycho-compiler-plugin source/target to 1.7 to fix the build failure: [ERROR] Cannot switch on a value of type String for source level below 1.7. Only convertible int values or enum variables are permitted
