### PR TITLE
issue #91: add tooltip to 'serialization protocol'

### DIFF
--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGMessages.properties
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGMessages.properties
@@ -32,6 +32,7 @@ TestNGMainTab.testng.loglevel=Log level (0-10)
 TestNGMainTab.testng.verbose=Verbose
 TestNGMainTab.testng.debug=Debug
 TestNGMainTab.testng.protocol=Serilization Protocol
+TestNGMainTab.testng.protocol.tooltip=Select the data serialization protocol for communicating between eclipse and TestNG runtime. Use "String Serialization" (though is deprecated, but still functional) as a workaround to bypass the socket "Broken pipe" issue https://github.com/cbeust/testng-eclipse/issues/91.
 TestNGMainTab.testng.protocol.object=Object Serialization
 TestNGMainTab.testng.protocol.string=String Serialization (Deprecated)
 

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGMainTab.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGMainTab.java
@@ -518,8 +518,10 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
 
     Label label = new Label(group, SWT.NONE);
     label.setText(ResourceUtil.getString("TestNGMainTab.testng.protocol"));
+    label.setToolTipText(ResourceUtil.getString("TestNGMainTab.testng.protocol.tooltip"));
 
     m_protocolComboViewer = new ComboViewer(group, SWT.READ_ONLY);
+    m_protocolComboViewer.getControl().setToolTipText(ResourceUtil.getString("TestNGMainTab.testng.protocol.tooltip"));
     GridDataFactory.fillDefaults().span(2, SWT.None).applyTo(m_protocolComboViewer.getCombo());
     m_protocolComboViewer.addSelectionChangedListener(new ISelectionChangedListener() {
       @Override


### PR DESCRIPTION
add tooltip to 'serialization protocol' to help user understand the options.