### PR TITLE
Issue/144 Timeout while trying to contact RemoteTestNG

### DIFF
--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGMessages.properties
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGMessages.properties
@@ -29,7 +29,7 @@ TestNGMainTab.projectdialog.message=Choose a project to constrain the search for
 TestNGMainTab.runtime.type=Runtime
 TestNGMainTab.resultviewer.title=Result Viewer
 TestNGMainTab.resultviewer.retries=Max Connection Retries
-TestNGMainTab.resultviewer.retries.tootip=Max Connection Retries when connect to RemoteTestNG
+TestNGMainTab.resultviewer.retries.tootip=The max Connection Retries when connect to RemoteTestNG. For example, the default timeout 5 sec (not configurable at the moment), and the default retries is 360, so the total wait time is 5 * 360 = 1800 sec. 
 TestNGMainTab.testng.compliance=Annotations compliance level (test sources needed for JDK 1.4) 
 TestNGMainTab.testng.loglevel=Log level (0-10)
 TestNGMainTab.testng.verbose=Verbose

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGMessages.properties
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGMessages.properties
@@ -27,6 +27,9 @@ TestNGMainTab.projectdialog.title=Project Selection
 TestNGMainTab.projectdialog.message=Choose a project to constrain the search for tests:
 
 TestNGMainTab.runtime.type=Runtime
+TestNGMainTab.resultviewer.title=Result Viewer
+TestNGMainTab.resultviewer.retries=Max Connection Retries
+TestNGMainTab.resultviewer.retries.tootip=Max Connection Retries when connect to RemoteTestNG
 TestNGMainTab.testng.compliance=Annotations compliance level (test sources needed for JDK 1.4) 
 TestNGMainTab.testng.loglevel=Log level (0-10)
 TestNGMainTab.testng.verbose=Verbose
@@ -73,6 +76,7 @@ CheckBoxTable.suites.title=Available suites
 TestSearchEngine.message.searching=Searching...
 
 TestRunnerViewPart.message.launching=Results of running {0}
+TestRunnerViewPart.message.startTestRunListening=TestNG Result Listening Job
 TestRunnerViewPart.toggle.vertical.label=Vertical View Orientation
 TestRunnerViewPart.toggle.horizontal.label=Horizontal View Orientation
 TestRunnerViewPart.toggle.automatic.label=Automatic View Orientation

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGMessages.properties
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGMessages.properties
@@ -77,6 +77,9 @@ TestSearchEngine.message.searching=Searching...
 
 TestRunnerViewPart.message.launching=Results of running {0}
 TestRunnerViewPart.message.startTestRunListening=TestNG Result Listening Job
+TestRunnerViewPart.message.suggestion1=Couldn't contact the RemoteTestNG client. Uncheck the 'Use Project testng.jar' option from your Project properties and try again.
+TestRunnerViewPart.message.suggestion2=Couldn't contact the RemoteTestNG client. Make sure you don't have an older version of testng.jar on your class path.
+TestRunnerViewPart.message.reason=Timeout while trying to contact RemoteTestNG.
 TestRunnerViewPart.toggle.vertical.label=Vertical View Orientation
 TestRunnerViewPart.toggle.horizontal.label=Horizontal View Orientation
 TestRunnerViewPart.toggle.automatic.label=Automatic View Orientation

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGMessages.properties
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGMessages.properties
@@ -30,6 +30,9 @@ TestNGMainTab.runtime.type=Runtime
 TestNGMainTab.resultviewer.title=Result Viewer
 TestNGMainTab.resultviewer.retries=Max Connection Retries
 TestNGMainTab.resultviewer.retries.tootip=The max Connection Retries when connect to RemoteTestNG. For example, the default timeout 5 sec (not configurable at the moment), and the default retries is 360, so the total wait time is 5 * 360 = 1800 sec. 
+TestNGMainTab.resultviewer.retries.err1=Current input is greater than the maximum limit ({0})
+TestNGMainTab.resultviewer.retries.err2=Current input is less than the minimum limit ({0}) 
+TestNGMainTab.resultviewer.retries.err3=Current input is not numeric. 
 TestNGMainTab.testng.compliance=Annotations compliance level (test sources needed for JDK 1.4) 
 TestNGMainTab.testng.loglevel=Log level (0-10)
 TestNGMainTab.testng.verbose=Verbose

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationConstants.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationConstants.java
@@ -61,7 +61,9 @@ public abstract class TestNGLaunchConfigurationConstants {
   public static final String GROUP_CLASS_LIST = make("GROUP_LIST_CLASS");
   
   public static final int DEFAULT_LOG_LEVEL = 2;
-  
+
+  public static final int DEFAULT_CONNECT_RETRIES = 600;
+
   /**
    * List of suites
    */
@@ -96,6 +98,8 @@ public abstract class TestNGLaunchConfigurationConstants {
   
   public static final String PROTOCOL = make("PROTOCOL");  //$NON-NLS-1$
   
+  public static final String CONNECT_RETRIES = make("CONNECT_RETRIES");  //$NON-NLS-1$
+
 //  public static final String TESTNG_COMPLIANCE_LEVEL_ATTR = make("COMPLIANCE_LEVEL"); //$NON-NLS-1$
   
   public static final String VM_ENABLEASSERTION_OPTION = "-ea";

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationConstants.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationConstants.java
@@ -62,7 +62,7 @@ public abstract class TestNGLaunchConfigurationConstants {
   
   public static final int DEFAULT_LOG_LEVEL = 2;
 
-  public static final int DEFAULT_CONNECT_RETRIES = 600;
+  public static final int DEFAULT_CONNECT_RETRIES = 360;
 
   /**
    * List of suites

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGMainTab.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGMainTab.java
@@ -280,9 +280,7 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
    */
   @Override
   public boolean isValid(ILaunchConfiguration launchConfig) {
-    boolean result = getErrorMessage() == null;
-
-    return result;
+    return getErrorMessage() == null;
   }
 
   /**
@@ -352,10 +350,8 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
           break;
         default:
           throw new IllegalArgumentException(UNKNOWN_CONSTANT + getType());
-
       }
     }
-
   }
 
   /**
@@ -555,7 +551,7 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
     label.setText(ResourceUtil.getString("TestNGMainTab.resultviewer.retries")); // $NON-NLS-1$
     label.setToolTipText(ResourceUtil.getString("TestNGMainTab.resultviewer.retries.tootip"));
 
-    m_connRetriesText = new Spinner(group, SWT.BORDER);
+    m_connRetriesText = new Spinner(group, SWT.SINGLE | SWT.BORDER);
     m_connRetriesText.setMinimum(1);
     m_connRetriesText.setMaximum(9999);
     m_connRetriesText.setIncrement(10);
@@ -564,6 +560,23 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
 
     m_connRetriesText.addModifyListener(new ModifyListener() {
       public void modifyText(ModifyEvent evt) {
+        final String string = m_connRetriesText.getText();
+        String message = null;
+        try {
+          final int value = Integer.parseInt(string);
+          final int maximum = m_connRetriesText.getMaximum();
+          final int minimum = m_connRetriesText.getMinimum();
+          if (value > maximum) {
+            message = ResourceUtil.getFormattedString("TestNGMainTab.resultviewer.retries.err1", maximum);
+          } else if (value < minimum) {
+            message = ResourceUtil.getFormattedString("TestNGMainTab.resultviewer.retries.err2", minimum);
+          }
+        } catch (final Exception ex) {
+          message = ResourceUtil.getString("TestNGMainTab.resultviewer.retries.err3");
+        }
+        if (message != null) {
+          setErrorMessage(message);
+        }
         updateLaunchConfigurationDialog();
       }
     });
@@ -636,10 +649,6 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
   public void updateDialog() {
     validatePage();
     updateLaunchConfigurationDialog();
-  }
-
-  public static void ppp(String s) {
-    System.out.println("[TestNGMainTab] " + s);
   }
 
   public IJavaProject getSelectedProject() {

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGMainTab.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGMainTab.java
@@ -551,10 +551,7 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
   private void createResultViewerGroup(Composite parent) {
     Group group = createGroup(parent, "TestNGMainTab.resultviewer.title"); //$NON-NLS-1$
 
-    GridData gd = new GridData(GridData.FILL_HORIZONTAL);
-    gd.horizontalSpan = 2;
-    Label label = new Label(group, SWT.LEFT);
-    label.setLayoutData(gd);
+    Label label = new Label(group, SWT.NONE);
     label.setText(ResourceUtil.getString("TestNGMainTab.resultviewer.retries")); // $NON-NLS-1$
     label.setToolTipText(ResourceUtil.getString("TestNGMainTab.resultviewer.retries.tootip"));
 
@@ -563,9 +560,7 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
     m_connRetriesText.setMaximum(9999);
     m_connRetriesText.setIncrement(10);
     m_connRetriesText.setPageIncrement(100);
-    gd = new GridData(GridData.HORIZONTAL_ALIGN_END | GridData.GRAB_HORIZONTAL);
-    gd.widthHint = 70;
-    m_connRetriesText.setLayoutData(gd);
+    GridDataFactory.fillDefaults().span(2, SWT.None).applyTo(m_connRetriesText);
 
     m_connRetriesText.addModifyListener(new ModifyListener() {
       public void modifyText(ModifyEvent evt) {
@@ -573,7 +568,7 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
       }
     });
   }
-  
+
   private void createProjectSelectionGroup(Composite comp) {
     Group projectGroup = createGroup(comp, "TestNGMainTab.label.project"); //$NON-NLS-1$
 

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGMainTab.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGMainTab.java
@@ -40,6 +40,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Spinner;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.SelectionDialog;
@@ -95,6 +96,9 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
 
   private ComboViewer m_protocolComboViewer;
 
+  // Result viewer group
+  private Spinner m_connRetriesText;
+
   private List <TestngTestSelector> m_launchSelectors = Lists.newArrayList();
   private Map<String, List<String>> m_classMethods;
 
@@ -115,6 +119,7 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
 
     createSelectors(group);
     createRuntimeGroup(comp);
+    createResultViewerGroup(comp);
   }
 
   private void createSelectors(Composite comp) {
@@ -224,6 +229,8 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
     setType(type);
     m_classMethods = ConfigurationHelper.getClassMethods(configuration);
 
+    m_connRetriesText.setSelection(ConfigurationHelper.getConnectReries(configuration));
+
     attachModificationListeners();
   }
 
@@ -263,7 +270,9 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
               m_logLevelCombo.getText(),
               m_verboseBtn.getSelection(),
               m_debugBtn.getSelection(),
-              (Protocols) ((StructuredSelection) m_protocolComboViewer.getSelection()).getFirstElement()));
+              (Protocols) ((StructuredSelection) m_protocolComboViewer.getSelection()).getFirstElement(),
+              m_connRetriesText.getSelection())
+        );
   }
 
   /**
@@ -539,6 +548,32 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
     m_protocolComboViewer.setInput(TestNGLaunchConfigurationConstants.SERIALIZATION_PROTOCOLS);
   }
 
+  private void createResultViewerGroup(Composite parent) {
+    Group group = createGroup(parent, "TestNGMainTab.resultviewer.title"); //$NON-NLS-1$
+
+    GridData gd = new GridData(GridData.FILL_HORIZONTAL);
+    gd.horizontalSpan = 2;
+    Label label = new Label(group, SWT.LEFT);
+    label.setLayoutData(gd);
+    label.setText(ResourceUtil.getString("TestNGMainTab.resultviewer.retries")); // $NON-NLS-1$
+    label.setToolTipText(ResourceUtil.getString("TestNGMainTab.resultviewer.retries.tootip"));
+
+    m_connRetriesText = new Spinner(group, SWT.BORDER);
+    m_connRetriesText.setMinimum(1);
+    m_connRetriesText.setMaximum(9999);
+    m_connRetriesText.setIncrement(10);
+    m_connRetriesText.setPageIncrement(100);
+    gd = new GridData(GridData.HORIZONTAL_ALIGN_END | GridData.GRAB_HORIZONTAL);
+    gd.widthHint = 70;
+    m_connRetriesText.setLayoutData(gd);
+
+    m_connRetriesText.addModifyListener(new ModifyListener() {
+      public void modifyText(ModifyEvent evt) {
+        updateLaunchConfigurationDialog();
+      }
+    });
+  }
+  
   private void createProjectSelectionGroup(Composite comp) {
     Group projectGroup = createGroup(comp, "TestNGMainTab.label.project"); //$NON-NLS-1$
 

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/TestRunnerViewPart.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/TestRunnerViewPart.java
@@ -83,6 +83,7 @@ import org.testng.ITestResult;
 import org.testng.eclipse.TestNGPlugin;
 import org.testng.eclipse.TestNGPluginConstants;
 import org.testng.eclipse.ui.summary.SummaryTab;
+import org.testng.eclipse.ui.util.ConfigurationHelper;
 import org.testng.eclipse.util.CustomSuite;
 import org.testng.eclipse.util.JDTUtil;
 import org.testng.eclipse.util.LaunchUtil;
@@ -363,7 +364,7 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
           @Override
           protected IStatus run(IProgressMonitor monitor) {
             int attempt = 0;
-            int maxRetries = 600;
+            int maxRetries = ConfigurationHelper.getConnectReries(launch.getLaunchConfiguration());
             boolean connected = false;
             while (connected == false && attempt++ <= maxRetries) {
               // handle cancel event
@@ -376,7 +377,7 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
                 connected = true;
               }
               catch(SocketTimeoutException ex) {
-                TestNGPlugin.log("TestNG viewer connect timeout, will retry " + attempt);
+                TestNGPlugin.log("TestNG viewer connect timeout, will retry " + attempt + ", max retries " + maxRetries);
               }
             }
 
@@ -398,7 +399,7 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
             else {
               newSuiteRunInfo(launch);
               fTestRunnerClient.startListening(currentSuiteRunInfo, currentSuiteRunInfo, messageMarshaller);
-  
+
               postSyncRunnable(new Runnable() {
                 public void run() {
                   m_rerunAction.setEnabled(true);
@@ -410,7 +411,7 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
             return Status.OK_STATUS;
           }
         };
-        
+
         // handle the process terminated event
         IDebugEventSetListener listener = new IDebugEventSetListener() {
           public void handleDebugEvents(DebugEvent[] events) {

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/TestRunnerViewPart.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/TestRunnerViewPart.java
@@ -385,11 +385,12 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
                   boolean useProjectJar =
                       TestNGPlugin.getPluginPreferenceStore().getUseProjectJar(project.getProject().getName());
                   String suggestion = useProjectJar
-                     ? "Uncheck the 'Use Project testng.jar' option from your Project properties and try again."
-                     : "Make sure you don't have an older version of testng.jar on your class path.";
-                  new ErrorDialog(m_counterComposite.getShell(), "Couldn't launch TestNG",
-                      "Couldn't contact the RemoteTestNG client. " + suggestion,
-                      new Status(IStatus.ERROR, TestNGPlugin.PLUGIN_ID, "Timeout while trying to contact RemoteTestNG."),
+                     ? ResourceUtil.getString("TestRunnerViewPart.message.suggestion1")
+                     : ResourceUtil.getString("TestRunnerViewPart.message.suggestion2");
+                  new ErrorDialog(m_counterComposite.getShell(),
+                      "Couldn't launch TestNG", suggestion,
+                      new Status(IStatus.ERROR, TestNGPlugin.PLUGIN_ID,
+                          ResourceUtil.getString("TestRunnerViewPart.message.reason")),
                       IStatus.ERROR).open();
                 }
               });

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/TestRunnerViewPart.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/TestRunnerViewPart.java
@@ -8,7 +8,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -31,7 +30,6 @@ import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.model.IProcess;
 import org.eclipse.debug.ui.DebugUITools;
 import org.eclipse.jdt.core.IJavaProject;
-import org.eclipse.jdt.internal.debug.ui.StatusInfo;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.IStatusLineManager;
@@ -391,7 +389,7 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
                      : "Make sure you don't have an older version of testng.jar on your class path.";
                   new ErrorDialog(m_counterComposite.getShell(), "Couldn't launch TestNG",
                       "Couldn't contact the RemoteTestNG client. " + suggestion,
-                      new StatusInfo(IStatus.ERROR, "Timeout while trying to contact RemoteTestNG."),
+                      new Status(IStatus.ERROR, TestNGPlugin.PLUGIN_ID, "Timeout while trying to contact RemoteTestNG."),
                       IStatus.ERROR).open();
                 }
               });
@@ -1038,12 +1036,6 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
     }
   }
 
-  private static void ppp(final Object message) {
-    if (true) {
-      System.out.println("[TestRunnerViewPart] " + message);
-    }
-  }
-
   /**
    * @see IWorkbenchPart#getTitleImage()
    */
@@ -1143,7 +1135,6 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
 
     @Override
     public void run() {
-      Workspace workspace = (Workspace) ResourcesPlugin.getWorkspace();
       IJavaProject javaProject= m_workingProject != null ? m_workingProject : JDTUtil.getJavaProjectContext();
       if(null == javaProject) {
         return;
@@ -1156,8 +1147,8 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
       if(isAbsolute) {
         IFile file = javaProject.getProject().getFile("temp-testng-index.html");
         try {
-          file.createLink(filePath, IResource.NONE, progressMonitor);
           if(null == file) return;
+          file.createLink(filePath, IResource.NONE, progressMonitor);
           try {
             openEditor(file);
           }
@@ -1166,18 +1157,18 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
           }
         }
         catch(CoreException cex) {
-          ; // TODO: is there any other option?
+          TestNGPlugin.log(cex);
         }
       }
       else {
-        IFile file= (IFile) workspace.newResource(filePath, IResource.FILE);
+        IFile file= ResourcesPlugin.getWorkspace().getRoot().getFile(filePath);
         if(null == file) return;
         try {
           file.refreshLocal(IResource.DEPTH_ZERO, progressMonitor);
           openEditor(file);
         }
         catch(CoreException cex) {
-          ; // nothing I can do about it
+          TestNGPlugin.log(cex); // nothing I can do about it
         }
       }
     }

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/util/ConfigurationHelper.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/util/ConfigurationHelper.java
@@ -43,7 +43,7 @@ public class ConfigurationHelper {
   
   public static class LaunchInfo {
     private String m_projectName;
-    private  LaunchType m_launchType;
+    private LaunchType m_launchType;
     private Collection<String> m_classNames;
     private Collection<String> m_packageNames;
     private Map<String, List<String>> m_classMethods;
@@ -54,6 +54,7 @@ public class ConfigurationHelper {
     private boolean m_verbose;
     private boolean m_debug;
     private Protocols m_protocol;
+    private int m_connRetries;
 
     public LaunchInfo(String projectName,
                       LaunchType launchType,
@@ -66,7 +67,8 @@ public class ConfigurationHelper {
                       String logLevel,
                       boolean verbose, 
                       boolean debug,
-                      Protocols protocol) {
+                      Protocols protocol,
+                      int connRetries) {
       m_projectName= projectName;
       m_launchType= launchType;
       m_classNames= classNames;
@@ -79,6 +81,7 @@ public class ConfigurationHelper {
       m_verbose = verbose;
       m_debug = debug;
       m_protocol = protocol;
+      m_connRetries = connRetries;
     }
   }
 
@@ -103,6 +106,12 @@ public class ConfigurationHelper {
   public static Protocols getProtocol(ILaunchConfiguration config) {
     String stringResult = getStringAttribute(config, TestNGLaunchConfigurationConstants.PROTOCOL);
     return null == stringResult ? TestNGLaunchConfigurationConstants.DEFAULT_SERIALIZATION_PROTOCOL : Protocols.get(stringResult); 
+  }
+
+  public static int getConnectReries(ILaunchConfiguration config) {
+    return getIntAttribute(config,
+        TestNGLaunchConfigurationConstants.CONNECT_RETRIES,
+        TestNGLaunchConfigurationConstants.DEFAULT_CONNECT_RETRIES);
   }
 
   public static String getSourcePath(ILaunchConfiguration config) {
@@ -257,17 +266,21 @@ public class ConfigurationHelper {
     
   }
 
-  private static int getIntAttribute(ILaunchConfiguration config, String attr) {
-    int result = 0;
-    
+  private static int getIntAttribute(ILaunchConfiguration config, String attr, int defValue) {
+    int result = defValue;
+
     try {
       result = config.getAttribute(attr, result);
     }
     catch (CoreException e) {
       TestNGPlugin.log(e);
     }
-    
+
     return result;
+  }
+
+  private static int getIntAttribute(ILaunchConfiguration config, String attr) {
+    return getIntAttribute(config, attr, 0);
   }
 
   private static boolean getBooleanAttribute(ILaunchConfiguration config, String attr) {
@@ -602,5 +615,6 @@ public class ConfigurationHelper {
     configuration.setAttribute(TestNGLaunchConfigurationConstants.VERBOSE, launchInfo.m_verbose);
     configuration.setAttribute(TestNGLaunchConfigurationConstants.DEBUG, launchInfo.m_debug);
     configuration.setAttribute(TestNGLaunchConfigurationConstants.PROTOCOL, launchInfo.m_protocol.toString());
+    configuration.setAttribute(TestNGLaunchConfigurationConstants.CONNECT_RETRIES, launchInfo.m_connRetries);
   }
 }


### PR DESCRIPTION
this is to fix issue #144 by polling the connection with several retries (default as 360, aka. the total wait time is 5 sec (timeout) * 360 = 1800 sec = 30 min)

max retries is configurable on the man launch tab:
[max retries](http://s13.postimg.org/vv8ra4xsl/main_tab_max_retries.png)

this also fix the issue #155
for example, add breakpoint at `java.util.Properties`, you can see the job is running wait for connection, rather than report timeout error and exit:
[job](http://s30.postimg.org/jl6ealznk/testng_job.jpg)

here is the log we can see it's polling (in eclipse log):
```
!ENTRY org.testng.eclipse 1 0 2015-08-16 04:19:28.968
!MESSAGE TestNG viewer connect timeout, will retry 3, max retries 360

!ENTRY org.testng.eclipse 1 0 2015-08-16 04:19:33.969
!MESSAGE TestNG viewer connect timeout, will retry 4, max retries 360

!ENTRY org.testng.eclipse 1 0 2015-08-16 04:19:38.975
!MESSAGE TestNG viewer connect timeout, will retry 5, max retries 360

!ENTRY org.testng.eclipse 1 0 2015-08-16 04:19:43.977
!MESSAGE TestNG viewer connect timeout, will retry 6, max retries 360

!ENTRY org.testng.eclipse 1 0 2015-08-16 04:19:48.981
!MESSAGE TestNG viewer connect timeout, will retry 7, max retries 360

!ENTRY org.testng.eclipse 1 0 2015-08-16 04:19:53.984
!MESSAGE TestNG viewer connect timeout, will retry 8, max retries 360
```