### PR TITLE
fixed #110: avoid unnecessary getVmArgs() call

### DIFF
--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/util/LaunchUtil.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/util/LaunchUtil.java
@@ -45,6 +45,7 @@ import org.testng.eclipse.TestNGPlugin;
 import org.testng.eclipse.TestNGPluginConstants;
 import org.testng.eclipse.launch.TestNGLaunchConfigurationConstants;
 import org.testng.eclipse.launch.TestNGLaunchConfigurationConstants.LaunchType;
+import org.testng.eclipse.launch.TestNGLaunchConfigurationConstants.Protocols;
 import org.testng.eclipse.ui.RunInfo;
 import org.testng.eclipse.ui.util.ConfigurationHelper;
 import org.testng.eclipse.util.JDTUtil.MethodDefinition;
@@ -415,8 +416,8 @@ public class LaunchUtil {
   }
 
   public static boolean useStringProtocol(ILaunchConfiguration configuration) {
-    String jvmArgs = ConfigurationHelper.getJvmArgs(configuration);
-     return jvmArgs.indexOf("-Dtestng.eclipse.stringprotocol") >= 0;
+    Protocols p = ConfigurationHelper.getProtocol(configuration);
+    return p == Protocols.STRING;
   }
 
   private static void launchTypeBasedConfiguration(IJavaProject javaProject, String confName,


### PR DESCRIPTION
the `VariablesPlugin.getDefault().getStringVariableManager().performStringSubstitution(result)` which invoked by `ConfigurationHelper.getJvmArgs()` will prompt InputDialog if there is ${string_prompt} in the launch config.
while `ConfigurationHelper.getJvmArgs()` was invoked by tree times when launching the test according the stack trace below:
* 1st
```
Thread [Worker-0] (Suspended (breakpoint at line 155 in ConfigurationHelper)) 
  ConfigurationHelper.getJvmArgs(ILaunchConfiguration) line: 155  
  TestNGLaunchConfigurationDelegate.launchTypes(ILaunchConfiguration, ILaunch, IJavaProject, int, String) line: 137 
  TestNGLaunchConfigurationDelegate.launch(ILaunchConfiguration, String, ILaunch, IProgressMonitor) line: 73  
  LaunchConfiguration.launch(String, IProgressMonitor, boolean, boolean) line: 885  
  LaunchConfiguration.launch(String, IProgressMonitor, boolean) line: 739 
  DebugUIPlugin.buildAndLaunch(ILaunchConfiguration, String, IProgressMonitor) line: 1039 
  DebugUIPlugin$8.run(IProgressMonitor) line: 1256  
  Worker.run() line: 54 
```
* 2nd
```
Thread [Worker-0] (Suspended (breakpoint at line 155 in ConfigurationHelper)) 
  ConfigurationHelper.getJvmArgs(ILaunchConfiguration) line: 155  
  LaunchUtil.useStringProtocol(ILaunchConfiguration) line: 418  
  TestNGLaunchConfigurationDelegate.createVMRunner(ILaunchConfiguration, ILaunch, IJavaProject, int, String) line: 221  
  TestNGLaunchConfigurationDelegate.launchTypes(ILaunchConfiguration, ILaunch, IJavaProject, int, String) line: 151 
  TestNGLaunchConfigurationDelegate.launch(ILaunchConfiguration, String, ILaunch, IProgressMonitor) line: 73  
  LaunchConfiguration.launch(String, IProgressMonitor, boolean, boolean) line: 885  
  LaunchConfiguration.launch(String, IProgressMonitor, boolean) line: 739 
  DebugUIPlugin.buildAndLaunch(ILaunchConfiguration, String, IProgressMonitor) line: 1039 
  DebugUIPlugin$8.run(IProgressMonitor) line: 1256  
  Worker.run() line: 54 
```
* 3rd
```
Thread [main] (Suspended (breakpoint at line 155 in ConfigurationHelper)) 
  owns: RunnableLock  (id=600)  
  ConfigurationHelper.getJvmArgs(ILaunchConfiguration) line: 155  
  LaunchUtil.useStringProtocol(ILaunchConfiguration) line: 418  
  TestRunnerViewPart.startTestRunListening(IJavaProject, String, int, ILaunch) line: 355  
  TestNGPlugin.connectTestRunner(ILaunch, IJavaProject, String, int) line: 213  
  TestNGPlugin$2.run() line: 201  
  RunnableLock.run() line: 35 
  UISynchronizer(Synchronizer).runAsyncMessages(boolean) line: 136  
  Display.runAsyncMessages(boolean) line: 3994  
  Display.readAndDispatch() line: 3671  
  PartRenderingEngine$9.run() line: 1151  
  Realm.runWithDefault(Realm, Runnable) line: 332 
  PartRenderingEngine.run(MApplicationElement, IEclipseContext) line: 1032  
  E4Workbench.createAndRunUI(MApplicationElement) line: 148 
  Workbench$5.run() line: 636 
  Realm.runWithDefault(Realm, Runnable) line: 332 
  Workbench.createAndRunWorkbench(Display, WorkbenchAdvisor) line: 579  
  PlatformUI.createAndRunWorkbench(Display, WorkbenchAdvisor) line: 150 
  IDEApplication.start(IApplicationContext) line: 135 
  EclipseAppHandle.run(Object) line: 196  
  EclipseAppLauncher.runApplication(Object) line: 134 
  EclipseAppLauncher.start(Object) line: 104  
  EclipseStarter.run(Object) line: 380  
  EclipseStarter.run(String[], Runnable) line: 235  
  NativeMethodAccessorImpl.invoke0(Method, Object, Object[]) line: not available [native method]  
  NativeMethodAccessorImpl.invoke(Object, Object[]) line: 62  
  DelegatingMethodAccessorImpl.invoke(Object, Object[]) line: 43  
  Method.invoke(Object, Object...) line: 497  
  Main.invokeFramework(String[], URL[]) line: 648 
  Main.basicRun(String[]) line: 603 
  Main.run(String[]) line: 1465 
  Main.main(String[]) line: 1438  
```

so the neat fix for issue #110 is simply avoid unnecessary call of `ConfigurationHelper.getJvmArgs(ILaunchConfiguration)`