### PR TITLE
issue #167: Distinguish test class instances when using Factory

### DIFF
--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/AbstractTab.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/AbstractTab.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
@@ -85,7 +86,9 @@ abstract public class AbstractTab extends TestRunTab implements IMenuListener {
   private Map<String, ITreeItem> m_suites = Maps.newHashMap();
   private Map<String, ITreeItem> m_tests = Maps.newHashMap();
   private Map<String, ITreeItem> m_classes = Maps.newHashMap();
-  private Map<String, ITreeItem> m_methods = Maps.newHashMap();
+  // bug/167: use ArrayListMultimap which allows duplicate keys to store m_methods
+  //          since the instanceName (which is used as key) might be same
+  private ArrayListMultimap<String, ITreeItem> m_methods = ArrayListMultimap.create();
   // Don't forget to .clear() all these maps beween each run ^^
 
   @Override
@@ -292,11 +295,8 @@ abstract public class AbstractTab extends TestRunTab implements IMenuListener {
         m_classes.put(pathToClass, cls);
       }
       String pathToMethod = pathToClass + "#" + runInfo.getMethodName();
-      ITreeItem method = m_methods.get(pathToMethod);
-      if (method == null) {
-        method = new TestMethodTreeItem(cls.getTreeItem(), runInfo);
-        m_methods.put(pathToMethod, method);
-      }
+      ITreeItem method = new TestMethodTreeItem(cls.getTreeItem(), runInfo);
+      m_methods.put(pathToMethod, method);
 
       // Create a node for the parameter values, if applicable
       ITreeItem methodParam = null;


### PR DESCRIPTION
@nemesis13 
thanks for your example, it's very helpful.
after look into the code, the name of the node on the "All Tests" tab like "1", "2", "3" are `instanceName" which is sent from TestNG runtime.
plugin does nothing but receive the runInfo and just display it.

according to the code of `org.testng.internal.TestResult.init(IClass, Object, ITestNGMethod, Throwable, long, long, ITestContext)`

```java
        String string = m_instance.toString();
        // Only display toString() if it's been overridden by the user
        m_name = getMethod().getMethodName();
        try {
          if (!Object.class.getMethod("toString")
              .equals(m_instance.getClass().getMethod("toString"))) {
            m_instanceName = string.startsWith("class ")
                ? string.substring("class ".length())
                : string;
            m_name = m_name + " on " + m_instanceName;
          }
        }
        catch(NoSuchMethodException ignore) {
          // ignore
        }
```

it looks like the instanceName here is intended to be the "full qualified class name" + "method name" by default, except the toString is overridden in the test class.

let's say at plugin side, it receives the runInfo, stores the testResult into a HashMap keyed with 'instanceName'. So that's the problem as HashMap doesn't allow duplicate key.

i don't want to change the instanceName behavior at TestNG side, so the fix at plugin side is just store the testResult into ArrayListMultimap which allows duplicate keys.

are you OK with the result view after this fix?
<img width="323" alt="fixed" src="https://cloud.githubusercontent.com/assets/555134/10251868/afb16272-68e8-11e5-9a68-3951ac4689fe.png">

