### PR TITLE
feature #168: running TestNG with the 'argLine' of maven-surefire-plugin from pom.xml by default

### DIFF
--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGMessages.properties
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGMessages.properties
@@ -34,6 +34,8 @@ TestNGMainTab.testng.protocol=Serilization Protocol
 TestNGMainTab.testng.protocol.tooltip=Select the data serialization protocol for communicating between eclipse and TestNG runtime. Use "String Serialization" (though is deprecated, but still functional) as a workaround to bypass the socket "Broken pipe" issue https://github.com/cbeust/testng-eclipse/issues/91.
 TestNGMainTab.testng.protocol.object=Object Serialization
 TestNGMainTab.testng.protocol.string=String Serialization (Deprecated)
+TestNGMainTab.testng.prefixVmArgsFromPom=Add the POM's JVM arguments when launching
+TestNGMainTab.testng.prefixVmArgsFromPom.tooltip=Enable this option to prefix the VM arguments defined in <argLine> of 'maven-surefire-plugin' or 'maven-failsafe-plugin' in pom.xml when launching. NOTE: only the first occurance of <argLine> is used, please disable this option if this is not expected behavior and explicitly set your VM arguments on the "Arguments" tab next to this tab. 
 
 TestNGMainTab.error.projectnotdefined=Project not specified
 TestNGMainTab.error.projectnotexists=Project {0} does not exist

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGPlugin.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGPlugin.java
@@ -285,10 +285,6 @@ public class TestNGPlugin extends AbstractUIPlugin implements ILaunchListener {
     }
   }
 
-  private static void ppp(final Object message) {
-//    System.out.println("[TestNG]:- " + message);
-  }
-
   // Assume that all the controls that go through bold() have the same font, 
   // which is probably a safe assumption.  The BOLD font will be disposed
   // in the stop() method
@@ -347,5 +343,9 @@ public class TestNGPlugin extends AbstractUIPlugin implements ILaunchListener {
 
   public static boolean isDebug() {
     return RemoteTestNG.isDebug();
+  }
+
+  public static IStatus createError(Throwable e) {
+    return new Status(IStatus.ERROR, PLUGIN_ID, e.getMessage(), e);
   }
 }

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationConstants.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationConstants.java
@@ -94,6 +94,8 @@ public abstract class TestNGLaunchConfigurationConstants {
   
   public static final String PROTOCOL = make("PROTOCOL");  //$NON-NLS-1$
 
+  public static final String PREFIX_VM_ARGS_FROM_POM = make("PREFIX_VM_ARGS_FROM_POM");  //$NON-NLS-1$
+
   public static final String VM_ENABLEASSERTION_OPTION = "-ea";
 
   public static final String PRE_DEFINED_LISTENERS=
@@ -127,6 +129,8 @@ public abstract class TestNGLaunchConfigurationConstants {
   
   public static final Protocols[] SERIALIZATION_PROTOCOLS = {Protocols.OBJECT, Protocols.STRING};
   public static final Protocols DEFAULT_SERIALIZATION_PROTOCOL = SERIALIZATION_PROTOCOLS[0];
+
+  public static final boolean DEFAULT_PREFIX_VM_ARGS_FROM_POM = true;
 
   public static enum Protocols {
     OBJECT("object"),

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationDelegate.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationDelegate.java
@@ -134,18 +134,7 @@ public class TestNGLaunchConfigurationDelegate extends AbstractJavaLaunchConfigu
     }
 
     // Program & VM args
-    StringBuilder vmArgs = new StringBuilder(ConfigurationHelper.getJvmArgs(configuration))
-        .append(" ")
-        .append(TestNGLaunchConfigurationConstants.VM_ENABLEASSERTION_OPTION); // $NON-NLS-1$
-    addDebugProperties(vmArgs, configuration);
-    switch (ConfigurationHelper.getProtocol(configuration)) {
-    case STRING:
-      vmArgs.append(" -Dtestng.eclipse.stringprotocol");
-      break;
-    default:
-      break;
-    }
-    ExecutionArguments execArgs = new ExecutionArguments(vmArgs.toString(), ""); //$NON-NLS-1$
+    ExecutionArguments execArgs = new ExecutionArguments(ConfigurationHelper.getJvmArgs(configuration), ""); //$NON-NLS-1$
     String[] envp = DebugPlugin.getDefault().getLaunchManager().getEnvironment(configuration);
 
     VMRunnerConfiguration runConfig = createVMRunner(configuration, launch, jproject, port, mode);
@@ -160,28 +149,6 @@ public class TestNGLaunchConfigurationDelegate extends AbstractJavaLaunchConfigu
     runConfig.setBootClassPath(bootpath);
 
     return runConfig;
-  }
-
-  /**
-   * Pass the system properties we were called with to the RemoteTestNG process.
-   */
-  private void addDebugProperties(StringBuilder vmArgs, ILaunchConfiguration config) {
-    String[] debugProperties = new String[] {
-        RemoteTestNG.PROPERTY_DEBUG,
-        RemoteTestNG.PROPERTY_VERBOSE
-    };
-    for (String p : debugProperties) {
-      if (System.getProperty(p) != null) {
-        vmArgs.append(" -D").append(p);
-      }
-    }
-
-    if (ConfigurationHelper.getVerbose(config)) {
-      vmArgs.append(" -D" + RemoteTestNG.PROPERTY_VERBOSE);
-    }
-    if (ConfigurationHelper.getDebug(config)) {
-      vmArgs.append(" -D" + RemoteTestNG.PROPERTY_DEBUG);
-    }
   }
 
   @Override

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGMainTab.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGMainTab.java
@@ -94,6 +94,8 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
   private Button m_debugBtn;
 
   private ComboViewer m_protocolComboViewer;
+  
+  private Button m_prefixVmArgsFromPomBtn;
 
   private List <TestngTestSelector> m_launchSelectors = Lists.newArrayList();
   private Map<String, List<String>> m_classMethods;
@@ -220,6 +222,8 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
 
     m_protocolComboViewer.setSelection(new StructuredSelection(ConfigurationHelper.getProtocol(configuration)));
 
+    m_prefixVmArgsFromPomBtn.setSelection(ConfigurationHelper.isPrefixVmArgsFromPom(configuration));
+
     LaunchType type = ConfigurationHelper.getType(configuration);
     setType(type);
     m_classMethods = ConfigurationHelper.getClassMethods(configuration);
@@ -262,7 +266,9 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
               m_logLevelCombo.getText(),
               m_verboseBtn.getSelection(),
               m_debugBtn.getSelection(),
-              (Protocols) ((StructuredSelection) m_protocolComboViewer.getSelection()).getFirstElement()));
+              (Protocols) ((StructuredSelection) m_protocolComboViewer.getSelection()).getFirstElement(),
+              m_prefixVmArgsFromPomBtn.getSelection())
+        );
   }
 
   /**
@@ -536,6 +542,21 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
       }
     });
     m_protocolComboViewer.setInput(TestNGLaunchConfigurationConstants.SERIALIZATION_PROTOCOLS);
+
+
+    m_prefixVmArgsFromPomBtn = new Button(group, SWT.CHECK);
+    m_prefixVmArgsFromPomBtn.setText(ResourceUtil.getString("TestNGMainTab.testng.prefixVmArgsFromPom"));
+    m_prefixVmArgsFromPomBtn.setToolTipText(ResourceUtil.getString("TestNGMainTab.testng.prefixVmArgsFromPom.tooltip"));
+    GridDataFactory.fillDefaults().span(3, SWT.None).applyTo(m_prefixVmArgsFromPomBtn);
+    m_prefixVmArgsFromPomBtn.addSelectionListener(new SelectionListener() {
+      public void widgetSelected(SelectionEvent e) {
+        updateLaunchConfigurationDialog();
+      }
+
+      public void widgetDefaultSelected(SelectionEvent e) {
+      }
+    });
+
   }
 
   private void createProjectSelectionGroup(Composite comp) {

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/QuickRunAction.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/QuickRunAction.java
@@ -76,8 +76,8 @@ public class QuickRunAction extends Action {
      * methods. 
      */
     ILaunchConfiguration config = m_previousRun.getLaunchConfiguration();
-    m_runInfo.setJvmArgs(ConfigurationHelper.getJvmArgs(config));
     try {
+      m_runInfo.setJvmArgs(ConfigurationHelper.getJvmArgs(config));
       m_runInfo.setEnvironmentVariables(config.getAttribute(
           ILaunchManager.ATTR_ENVIRONMENT_VARIABLES, (Map<String, String>) null));
     } catch (CoreException e) {

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/conversion/JUnitRewriteCorrectionProposal.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/conversion/JUnitRewriteCorrectionProposal.java
@@ -29,6 +29,7 @@ import org.eclipse.text.edits.ReplaceEdit;
 import org.eclipse.text.edits.TextEdit;
 import org.eclipse.text.edits.TextEditVisitor;
 import org.eclipse.text.edits.UndoEdit;
+import org.testng.eclipse.TestNGPlugin;
 import org.testng.eclipse.ui.Images;
 
 /**
@@ -111,7 +112,7 @@ public class JUnitRewriteCorrectionProposal implements IJavaCompletionProposal
         TextEdit edit= rewrite.rewriteAST();
         editRoot.addChild(edit);
       } catch (IllegalArgumentException e) {
-        throw new CoreException(JavaUIStatus.createError(IStatus.ERROR, e));
+        throw new CoreException(TestNGPlugin.createError(e));
       }
     }
 //    if (fImportRewrite != null) {

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/util/ConfigurationHelper.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/util/ConfigurationHelper.java
@@ -9,10 +9,19 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathFactory;
+
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.variables.VariablesPlugin;
 import org.eclipse.debug.core.ILaunch;
@@ -21,6 +30,7 @@ import org.eclipse.debug.core.ILaunchConfigurationType;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.testng.eclipse.TestNGPlugin;
@@ -33,6 +43,9 @@ import org.testng.eclipse.util.StringUtils;
 import org.testng.eclipse.util.SuiteGenerator;
 import org.testng.remote.RemoteTestNG;
 import org.testng.xml.LaunchSuite;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 /**
  * Helper methods to store and retrieve values from a launch configuration.
@@ -152,6 +165,15 @@ public class ConfigurationHelper {
    * @return the JVM args from the configuration or, if not found, from the preferences.
    */
   public static String getJvmArgs(ILaunchConfiguration configuration) {
+    StringBuilder jvmArgs = new StringBuilder();
+    jvmArgs.append(TestNGLaunchConfigurationConstants.VM_ENABLEASSERTION_OPTION);
+
+    try {
+      jvmArgs.append(getVMArgsFromPom(configuration));
+    } catch (Exception e1) {
+      TestNGPlugin.log(e1);
+    }
+
     String result = getProjectJvmArgs();
 
     // JVM args from the previous configuration take precedence over the preference
@@ -165,9 +187,96 @@ public class ConfigurationHelper {
   		}
     }
 
-    return result;
-	}
-  
+    jvmArgs.append(" ").append(result);
+
+    addDebugProperties(jvmArgs, configuration);
+
+    switch (ConfigurationHelper.getProtocol(configuration)) {
+    case STRING:
+      jvmArgs.append(" -Dtestng.eclipse.stringprotocol");
+      break;
+    default:
+      break;
+    }
+
+    return jvmArgs.toString();
+  }
+
+  /**
+   * Get the JVM args from maven pom.xmll.
+   * <ul>
+   * Here is the return value of different cases:
+   * <li>no pom.xml -- return empty String</li>
+   * <li>pom.xml exists, but no maven-surefire-plugin or maven-safefail-plugin, in essential, no "argLine" element in the pom.xml -- return empty String</li>
+   * <li>there is one "argLine" element -- return the text content of the "argLine" element</li>
+   * <li>there are more then one "argLine" elements -- return the first "argLine"<profile></li>
+   * </ul>
+   * @param conf
+   * @return
+   * @throws Exception
+   */
+  private static String getVMArgsFromPom(ILaunchConfiguration conf) throws Exception {
+    StringBuilder vmArgs = new StringBuilder();
+    IJavaProject javaProject = getJavaProject(conf);
+    IFile pomFile = javaProject.getProject().getFile("pom.xml");
+    if (pomFile.exists()) {
+      DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+      documentBuilderFactory.setNamespaceAware(false);
+      DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+      Document doc = documentBuilder.parse(pomFile.getLocation().toFile());
+
+      XPathFactory xpathFactory = XPathFactory.newInstance();
+      XPath xpath = xpathFactory.newXPath();
+
+      XPathExpression expr = xpath.compile("//argLine");
+      NodeList argLineNodes = (NodeList) expr.evaluate(doc, XPathConstants.NODESET);
+      if (argLineNodes.getLength() > 0) {
+        Node argLineNode = argLineNodes.item(0);
+        vmArgs.append(" ").append(argLineNode.getTextContent());
+      }
+    }
+    return vmArgs.toString();
+  }
+
+  /**
+   * Pass the system properties we were called with to the RemoteTestNG process.
+   */
+  private static void addDebugProperties(StringBuilder vmArgs, ILaunchConfiguration config) {
+    String[] debugProperties = new String[] {
+        RemoteTestNG.PROPERTY_DEBUG,
+        RemoteTestNG.PROPERTY_VERBOSE
+    };
+    for (String p : debugProperties) {
+      if (System.getProperty(p) != null) {
+        vmArgs.append(" -D").append(p);
+      }
+    }
+
+    if (ConfigurationHelper.getVerbose(config)) {
+      vmArgs.append(" -D" + RemoteTestNG.PROPERTY_VERBOSE);
+    }
+    if (ConfigurationHelper.getDebug(config)) {
+      vmArgs.append(" -D" + RemoteTestNG.PROPERTY_DEBUG);
+    }
+  }
+
+  public static IJavaProject getJavaProject(ILaunchConfiguration configuration)
+      throws CoreException {
+    String projectName = getProjectName(configuration);
+    if (projectName != null) {
+      projectName = projectName.trim();
+      if (projectName.length() > 0) {
+        IProject project = ResourcesPlugin.getWorkspace().getRoot()
+            .getProject(projectName);
+        IJavaProject javaProject = JavaCore.create(project);
+        if (javaProject != null && javaProject.exists()) {
+          return javaProject;
+        }
+      }
+    }
+    return null;
+  }
+
   public static ILaunchConfigurationWorkingCopy setJvmArgs(
 			ILaunchConfigurationWorkingCopy configuration, String args) {
 		configuration.setAttribute(
@@ -298,14 +407,6 @@ public class ConfigurationHelper {
                         RemoteTestNG.class.getName());
     config.setAttribute(TestNGLaunchConfigurationConstants.TYPE, LaunchType.CLASS.ordinal());
     config.setAttribute(TestNGLaunchConfigurationConstants.LOG_LEVEL, "2");
-  }
-
-  private static String computeRelativePath(final String rootPath, final String sourcePath) {
-    File rootFile = new File(rootPath);
-    String rootRelativeName = rootFile.getName();
-    
-    int idx = sourcePath.indexOf(rootPath);
-    return File.separator + rootRelativeName + sourcePath.substring(idx + rootPath.length());
   }
 
   /**

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/util/LaunchUtil.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/util/LaunchUtil.java
@@ -138,7 +138,7 @@ public class LaunchUtil {
         configWC.setAttribute(ILaunchManager.ATTR_ENVIRONMENT_VARIABLES, previousEnv);
       }
     } catch (CoreException e) {
-      e.printStackTrace();
+      TestNGPlugin.log(e);
     }
 
     configWC.setAttribute(TestNGLaunchConfigurationConstants.SUITE_TEST_LIST,
@@ -148,18 +148,23 @@ public class LaunchUtil {
 
     // carry over jvm args from prevConfig
     // set failed test jvm args
-    String jargs = ConfigurationHelper.getJvmArgs(prevConfig);
-    if (jargs != null) ConfigurationHelper.setJvmArgs(configWC, jargs);
-    if (failureDescriptions != null && failureDescriptions.size() > 0) {
-    	Iterator it = failureDescriptions.iterator();
-    	StringBuffer buf = new StringBuffer();
-  		boolean first = true;
-  		while (it.hasNext()) {
-  			if (first) first = false;
-  			else buf.append(",");
-  			buf.append (it.next());
-  		}
-  		setFailedTestsJvmArg(buf.toString(), configWC);
+    try {
+      String jargs = ConfigurationHelper.getJvmArgs(prevConfig);
+      if (jargs != null) ConfigurationHelper.setJvmArgs(configWC, jargs);
+      if (failureDescriptions != null && failureDescriptions.size() > 0) {
+      	Iterator it = failureDescriptions.iterator();
+      	StringBuffer buf = new StringBuffer();
+    		boolean first = true;
+    		while (it.hasNext()) {
+    			if (first) first = false;
+    			else buf.append(",");
+    			buf.append (it.next());
+    		}
+    		setFailedTestsJvmArg(buf.toString(), configWC);
+      }
+    } catch (CoreException e) {
+      // TODO throw the exception rather than catch it
+      TestNGPlugin.log(e);
     }
     runConfig(configWC, mode);
   }


### PR DESCRIPTION
implement the new feature that recognize the argLine from pom.xml when run test cases.
by default, it uses the first argLine (if there is more than one argLine in the pom.xml), if the value is not expected, the user still can explicitly override in "VM arguments" on the "Arguments" tab of the run/debug configuration.