### PR TITLE
auto compute orientation when re-sizing the view part if automatic is…

### DIFF
--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/TestRunnerViewPart.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/TestRunnerViewPart.java
@@ -43,6 +43,8 @@ import org.eclipse.jface.util.PropertyChangeEvent;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabItem;
+import org.eclipse.swt.events.ControlEvent;
+import org.eclipse.swt.events.ControlListener;
 import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.KeyListener;
 import org.eclipse.swt.events.SelectionAdapter;
@@ -250,6 +252,16 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
     }
 
     computeOrientation();
+  }
+
+  private void addResizeListener(Composite parent) {
+    parent.addControlListener(new ControlListener() {
+      public void controlMoved(ControlEvent e) {
+      }
+      public void controlResized(ControlEvent e) {
+        computeOrientation();
+      }
+    });
   }
 
   void computeOrientation() {
@@ -709,10 +721,12 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
 
   @Override
   public void createPartControl(Composite parent) {
+    m_parentComposite = parent;
+    addResizeListener(parent);
+
     if (getWatchResultDirectory() != null) {
       updateResultThread();
     }
-    m_parentComposite = new Composite(parent, SWT.NONE);
 
     GridLayoutFactory.fillDefaults().applyTo(m_parentComposite);
 
@@ -816,7 +830,7 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
 
   private void createProgressCountPanel(Composite parent) {
     Composite c = new Composite(parent, SWT.NONE);
-    GridDataFactory.fillDefaults().grab(true, true).applyTo(c);
+    GridDataFactory.fillDefaults().grab(true, false).applyTo(c);
     GridLayoutFactory.swtDefaults().applyTo(c);
 
     Display display= parent.getDisplay();


### PR DESCRIPTION
auto compute orientation when re-sizing the view part if automatic is checked.

before:

<img width="300" alt="auto1" src="https://cloud.githubusercontent.com/assets/555134/10537018/2c3128a8-73a4-11e5-93c7-2eecdf0d47fd.png">

after:

<img width="298" alt="auto2" src="https://cloud.githubusercontent.com/assets/555134/10537037/3ee5c800-73a4-11e5-91f8-d0a6666b9a55.png">

