### PR TITLE
issue #60: kill process only if people click the stop button

### DIFF
--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/TestRunnerViewPart.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/TestRunnerViewPart.java
@@ -321,7 +321,6 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
       fTestRunnerClient.stopTest();
     }
     stopUpdateJobs();
-    stopProcess();
   }
 
   public void selectNextFailure() {
@@ -903,6 +902,8 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
       m_stopButton.addSelectionListener(new SelectionListener() {
         public void widgetSelected(SelectionEvent e) {
           stopTest();
+          // kill process only if people click the stop button
+          stopProcess();
           m_stopButton.setEnabled(false);
         }
 


### PR DESCRIPTION
kill process only if people click the stop button, for normal case we just leave it as is so that JVM can perform the rescue release as demand by the test cases.