### PR TITLE
issue #91: verify the minimum required version of testng

### DIFF
--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGMessages.properties
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGMessages.properties
@@ -49,6 +49,7 @@ TestNGMainTab.error.methodnotdefined=Method not specified
 TestNGLaunchConfigurationDelegate.error.invalidproject=Invalid project
 TestNGLaunchConfigurationDelegate.error.novmrunner=No runtime VM runner for VM Install {0}
 TestNGLaunchConfigurationDelegate.error.incompatiblevmversion=VM version {0} is invalid, Java 1.7 or above is required for running TestNG.
+TestNGLaunchConfigurationDelegate.error.testngVersionUnsupported=TestNG 6.5.1 or above is required, please update your TestNG or uncheck 'Use project TestNG jar' from preference
 
 CounterPanel.label.passed=Passed
 CounterPanel.label.failed=Failed

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGPlugin.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGPlugin.java
@@ -348,4 +348,8 @@ public class TestNGPlugin extends AbstractUIPlugin implements ILaunchListener {
   public static IStatus createError(Throwable e) {
     return new Status(IStatus.ERROR, PLUGIN_ID, e.getMessage(), e);
   }
+  
+  public static IStatus createError(String message) {
+    return new Status(IStatus.ERROR, PLUGIN_ID, message);
+  }
 }


### PR DESCRIPTION
this is a supplementary PR for issue #91
check the minimum required version of testng when launch by parsing the manifest of the first presence of testng jar on the classpath:
<img width="411" alt="testng_version" src="https://cloud.githubusercontent.com/assets/555134/10609299/dab324fc-76f7-11e5-8870-c01a72cd1e91.png">
