### PR TITLE
feature #168: move option to workspace and project level

### DIFF
--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGMessages.properties
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGMessages.properties
@@ -34,8 +34,6 @@ TestNGMainTab.testng.protocol=Serilization Protocol
 TestNGMainTab.testng.protocol.tooltip=Select the data serialization protocol for communicating between eclipse and TestNG runtime. Use "String Serialization" (though is deprecated, but still functional) as a workaround to bypass the socket "Broken pipe" issue https://github.com/cbeust/testng-eclipse/issues/91.
 TestNGMainTab.testng.protocol.object=Object Serialization
 TestNGMainTab.testng.protocol.string=String Serialization (Deprecated)
-TestNGMainTab.testng.prefixVmArgsFromPom=Add the POM's JVM arguments when launching
-TestNGMainTab.testng.prefixVmArgsFromPom.tooltip=Enable this option to prefix the VM arguments defined in <argLine> of 'maven-surefire-plugin' or 'maven-failsafe-plugin' in pom.xml when launching. NOTE: only the first occurance of <argLine> is used, please disable this option if this is not expected behavior and explicitly set your VM arguments on the "Arguments" tab next to this tab. 
 
 TestNGMainTab.error.projectnotdefined=Project not specified
 TestNGMainTab.error.projectnotexists=Project {0} does not exist
@@ -137,6 +135,9 @@ TestNGPropertyPage.watchResultXml=Watch testng-results.xml
 TestNGPropertyPage.resultXmlDirectory=Directory:
 TestNGPropertyPage.preDefinedListeners=Pre Defined Listeners:
 TestNGPropertyPage.useProjectTestNGJar=Use project TestNG jar
+TestNGPropertyPage.group.maven=Pass to TestNG process following maven plugin settings
+TestNGPropertyPage.prefixVmArgsFromPom=argLine
+TestNGPropertyPage.prefixVmArgsFromPom.tooltip=Enable this option to prefix the VM arguments defined in <argLine> of 'maven-surefire-plugin' or 'maven-failsafe-plugin' in pom.xml when launching. NOTE: only the first occurance of <argLine> is used, please disable this option if this is not expected behavior and explicitly set your VM arguments on the "Arguments" tab next to this tab. 
 
 
 NewTestNGClassWizardPage.title=New TestNG class

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGPluginConstants.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGPluginConstants.java
@@ -16,6 +16,8 @@ public abstract class TestNGPluginConstants {
   public static final String S_ABSOLUTEPATH= ".absolutepath"; //$NON-NLS-1$
   public static final String S_USEPROJECTJAR= ".useProjectJar"; //$NON-NLS-1$
   public static final String S_USEPROJECTJAR_GLOBAL= "_TESTNG_ECLIPSE" + S_USEPROJECTJAR; //$NON-NLS-1$
+  public static final String S_PREFIX_VM_ARGS_FROM_POM= ".prefixVmArgsFromPom"; //$NON-NLS-1$
+  public static final String S_PREFIX_VM_ARGS_FROM_POM_GLOBAL= "_TESTNG_ECLIPSE" + S_PREFIX_VM_ARGS_FROM_POM; //$NON-NLS-1$
 //  public static final String S_REPORTERS = ".reporters";
   public static final String S_DISABLEDLISTENERS = ".disabledListeners";
 //  public static final String S_PARALLEL = ".parallel";

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationConstants.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationConstants.java
@@ -94,8 +94,6 @@ public abstract class TestNGLaunchConfigurationConstants {
   
   public static final String PROTOCOL = make("PROTOCOL");  //$NON-NLS-1$
 
-  public static final String PREFIX_VM_ARGS_FROM_POM = make("PREFIX_VM_ARGS_FROM_POM");  //$NON-NLS-1$
-
   public static final String VM_ENABLEASSERTION_OPTION = "-ea";
 
   public static final String PRE_DEFINED_LISTENERS=
@@ -129,8 +127,6 @@ public abstract class TestNGLaunchConfigurationConstants {
   
   public static final Protocols[] SERIALIZATION_PROTOCOLS = {Protocols.OBJECT, Protocols.STRING};
   public static final Protocols DEFAULT_SERIALIZATION_PROTOCOL = SERIALIZATION_PROTOCOLS[0];
-
-  public static final boolean DEFAULT_PREFIX_VM_ARGS_FROM_POM = true;
 
   public static enum Protocols {
     OBJECT("object"),

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGMainTab.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGMainTab.java
@@ -222,8 +222,6 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
 
     m_protocolComboViewer.setSelection(new StructuredSelection(ConfigurationHelper.getProtocol(configuration)));
 
-    m_prefixVmArgsFromPomBtn.setSelection(ConfigurationHelper.isPrefixVmArgsFromPom(configuration));
-
     LaunchType type = ConfigurationHelper.getType(configuration);
     setType(type);
     m_classMethods = ConfigurationHelper.getClassMethods(configuration);
@@ -266,8 +264,7 @@ public class TestNGMainTab extends AbstractLaunchConfigurationTab implements ILa
               m_logLevelCombo.getText(),
               m_verboseBtn.getSelection(),
               m_debugBtn.getSelection(),
-              (Protocols) ((StructuredSelection) m_protocolComboViewer.getSelection()).getFirstElement(),
-              m_prefixVmArgsFromPomBtn.getSelection())
+              (Protocols) ((StructuredSelection) m_protocolComboViewer.getSelection()).getFirstElement())
         );
   }
 

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/preferences/PreferenceInitializer.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/preferences/PreferenceInitializer.java
@@ -28,6 +28,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
     store.setDefault(TestNGPluginConstants.S_SHOW_VIEW_WHEN_TESTS_COMPLETE,
         true);
     store.setDefault(TestNGPluginConstants.S_USEPROJECTJAR_GLOBAL, true);
+    store.setDefault(TestNGPluginConstants.S_PREFIX_VM_ARGS_FROM_POM_GLOBAL, false);
   }
 
 }

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/preferences/ProjectPropertyPage.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/preferences/ProjectPropertyPage.java
@@ -61,6 +61,8 @@ public class ProjectPropertyPage extends PropertyPage {
   private Button m_projectJar;
   private Text m_watchResultText;
   private Button m_watchResultRadio;
+  // maven group
+  private Button m_prefixVmArgsFromPom;
 
   public void createControl(Composite parent) {
     setDescription("Project TestNG settings");
@@ -175,11 +177,23 @@ public class ProjectPropertyPage extends PropertyPage {
       m_preDefinedListeners = w.text;
       m_preDefinedListeners.setToolTipText("Split multi listener using ;");
     }
+
+    //
+    // maven group
+    //
+    Group mavenGroup = new Group(parentComposite, SWT.BORDER);
+    GridDataFactory.fillDefaults().grab(true, false).applyTo(mavenGroup);
+    GridLayoutFactory.fillDefaults().applyTo(mavenGroup);
+    mavenGroup.setText(ResourceUtil.getString("TestNGPropertyPage.group.maven"));
+
+    m_prefixVmArgsFromPom = new Button(mavenGroup, SWT.CHECK);
+    m_prefixVmArgsFromPom.setText(ResourceUtil.getString("TestNGPropertyPage.prefixVmArgsFromPom"));
+    m_prefixVmArgsFromPom.setToolTipText(ResourceUtil.getString("TestNGPropertyPage.prefixVmArgsFromPom.tooltip"));
+
     loadDefaults();
 
     return parentComposite;
   }
-
   
   public void dispose() {
     m_projectJar.dispose();
@@ -188,7 +202,9 @@ public class ProjectPropertyPage extends PropertyPage {
     m_disabledDefaultListeners.dispose();
     m_xmlTemplateFile.dispose();
     m_preDefinedListeners.dispose();
-    
+
+    m_prefixVmArgsFromPom.dispose();
+
     super.dispose();
   }
 
@@ -207,6 +223,7 @@ public class ProjectPropertyPage extends PropertyPage {
     String dir = storage.getWatchResultDirectory(projectName);
     m_watchResultText.setText(dir);
     m_preDefinedListeners.setText(storage.getPreDefinedListeners(projectName, false));
+    m_prefixVmArgsFromPom.setSelection(storage.isPrefixVmArgsFromPom(projectName));
   }
 
   protected void performDefaults() {
@@ -224,6 +241,7 @@ public class ProjectPropertyPage extends PropertyPage {
     storage.storeUseProjectJar(projectName, m_projectJar.getSelection());
     storage.storeWatchResults(projectName, m_watchResultRadio.getSelection());
     storage.storeWatchResultLocation(projectName, m_watchResultText.getText());
+    storage.storePrefixVmArgsFromPom(projectName, m_prefixVmArgsFromPom.getSelection());
 
     if(super.performOk()) {
       setMessage("Project preferences are saved", INFORMATION);

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/preferences/WorkspacePreferencePage.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/preferences/WorkspacePreferencePage.java
@@ -5,6 +5,7 @@ import java.io.File;
 
 import org.eclipse.debug.internal.ui.preferences.BooleanFieldEditor2;
 import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.jface.preference.DirectoryFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.FileFieldEditor;
@@ -15,6 +16,7 @@ import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Group;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.testng.eclipse.TestNGPlugin;
@@ -36,6 +38,8 @@ public class WorkspacePreferencePage
   private FileFieldEditor m_xmlTemplateFile;
   private StringFieldEditor m_excludedStackTraces;
   private StringFieldEditor m_preDefinedListeners;
+  // maven group
+  private BooleanFieldEditor2 m_prefixVmArgsFromPom;
   
   public WorkspacePreferencePage() {
     super(GRID);
@@ -103,7 +107,14 @@ public class WorkspacePreferencePage
     m_preDefinedListeners = new StringFieldEditor(TestNGPluginConstants.S_PRE_DEFINED_LISTENERS,
         "Pre Defined Listeners", parentComposite);
     
-    
+    Group mavenGroup = new Group(parentComposite, SWT.BORDER);
+    GridDataFactory.fillDefaults().grab(true, false).span(3, SWT.DEFAULT).applyTo(mavenGroup);
+    GridLayoutFactory.fillDefaults().applyTo(mavenGroup);
+    mavenGroup.setText(ResourceUtil.getString("TestNGPropertyPage.group.maven"));
+    m_prefixVmArgsFromPom = new BooleanFieldEditor2(
+        TestNGPluginConstants.S_PREFIX_VM_ARGS_FROM_POM_GLOBAL, 
+        ResourceUtil.getString("TestNGPropertyPage.prefixVmArgsFromPom"), SWT.NONE, mavenGroup);
+
     addField(m_outputdir);
     addField(m_absolutePath);
     addField(m_disabledDefaultListeners);
@@ -112,6 +123,7 @@ public class WorkspacePreferencePage
     addField(m_xmlTemplateFile);
     addField(m_excludedStackTraces);
     addField(m_preDefinedListeners);
+    addField(m_prefixVmArgsFromPom);
   }
 
   /* (non-Javadoc)

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/util/ConfigurationHelper.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/util/ConfigurationHelper.java
@@ -39,6 +39,7 @@ import org.testng.eclipse.launch.TestNGLaunchConfigurationConstants;
 import org.testng.eclipse.launch.TestNGLaunchConfigurationConstants.LaunchType;
 import org.testng.eclipse.launch.TestNGLaunchConfigurationConstants.Protocols;
 import org.testng.eclipse.ui.RunInfo;
+import org.testng.eclipse.util.PreferenceStoreUtil;
 import org.testng.eclipse.util.StringUtils;
 import org.testng.eclipse.util.SuiteGenerator;
 import org.testng.remote.RemoteTestNG;
@@ -66,7 +67,6 @@ public class ConfigurationHelper {
     private boolean m_verbose;
     private boolean m_debug;
     private Protocols m_protocol;
-    private boolean m_prefixVmArgsFromPom;
 
     public LaunchInfo(String projectName,
                       LaunchType launchType,
@@ -78,8 +78,7 @@ public class ConfigurationHelper {
                       String logLevel,
                       boolean verbose,
                       boolean debug,
-                      Protocols protocol,
-                      boolean prefixVmArgsFromPom) {
+                      Protocols protocol) {
       m_projectName= projectName;
       m_launchType= launchType;
       m_classNames= classNames;
@@ -91,7 +90,6 @@ public class ConfigurationHelper {
       m_verbose = verbose;
       m_debug = debug;
       m_protocol = protocol;
-      m_prefixVmArgsFromPom = prefixVmArgsFromPom;
     }
   }
 
@@ -116,11 +114,6 @@ public class ConfigurationHelper {
   public static Protocols getProtocol(ILaunchConfiguration config) {
     String stringResult = getStringAttribute(config, TestNGLaunchConfigurationConstants.PROTOCOL);
     return null == stringResult ? TestNGLaunchConfigurationConstants.DEFAULT_SERIALIZATION_PROTOCOL : Protocols.get(stringResult); 
-  }
-
-  public static boolean isPrefixVmArgsFromPom(ILaunchConfiguration config) {
-    return getBooleanAttribute(config, TestNGLaunchConfigurationConstants.PREFIX_VM_ARGS_FROM_POM, 
-        TestNGLaunchConfigurationConstants.DEFAULT_PREFIX_VM_ARGS_FROM_POM);
   }
 
   public static String getSourcePath(ILaunchConfiguration config) {
@@ -216,8 +209,8 @@ public class ConfigurationHelper {
    */
   private static String getVMArgsFromPom(ILaunchConfiguration conf) throws Exception {
     StringBuilder vmArgs = new StringBuilder();
-    if (isPrefixVmArgsFromPom(conf)) {
-      IJavaProject javaProject = getJavaProject(conf);
+    IJavaProject javaProject = getJavaProject(conf);
+    if (TestNGPlugin.getPluginPreferenceStore().isPrefixVmArgsFromPom(javaProject.getProject().getName())) {
       IFile pomFile = javaProject.getProject().getFile("pom.xml");
       if (pomFile.exists()) {
         DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
@@ -650,6 +643,5 @@ public class ConfigurationHelper {
     configuration.setAttribute(TestNGLaunchConfigurationConstants.VERBOSE, launchInfo.m_verbose);
     configuration.setAttribute(TestNGLaunchConfigurationConstants.DEBUG, launchInfo.m_debug);
     configuration.setAttribute(TestNGLaunchConfigurationConstants.PROTOCOL, launchInfo.m_protocol.toString());
-    configuration.setAttribute(TestNGLaunchConfigurationConstants.PREFIX_VM_ARGS_FROM_POM, launchInfo.m_prefixVmArgsFromPom);
   }
 }

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/util/PreferenceStoreUtil.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/util/PreferenceStoreUtil.java
@@ -49,6 +49,15 @@ public class PreferenceStoreUtil {
     m_storage.setValue(projectName + TestNGPluginConstants.S_USEPROJECTJAR, strUsePrjJar);
   }
 
+  public void storePrefixVmArgsFromPom(String projectName, boolean selection) {
+    String strPrefixVmArgsFromPom = String.valueOf(selection);
+    // here store the string value rather than boolean is to prevent the value being removed from store,
+    // which cause it's hard to know wheter the value should read from global or project level
+    // now by explicitly set the value "true" or "false" to know it's at project level,
+    // otherwise, it comes from global level
+    m_storage.setValue(projectName + TestNGPluginConstants.S_PREFIX_VM_ARGS_FROM_POM, strPrefixVmArgsFromPom);
+  }
+
   public void storeXmlTemplateFile(String projectName, String xmlFile) {
     m_storage.setValue(projectName + TestNGPluginConstants.S_XML_TEMPLATE_FILE, xmlFile);
   }
@@ -162,6 +171,16 @@ public class PreferenceStoreUtil {
           .getBoolean(TestNGPluginConstants.S_USEPROJECTJAR_GLOBAL);
     }
     return Boolean.valueOf(strUsePrjJar).booleanValue();
+  }
+
+  public boolean isPrefixVmArgsFromPom(String projectName) {
+    String prefixVmArgsFromPom = m_storage.getString(projectName + TestNGPluginConstants.S_PREFIX_VM_ARGS_FROM_POM);
+    // if no project level setting, query from global
+    if (prefixVmArgsFromPom == null || prefixVmArgsFromPom.isEmpty()) {
+      return TestNGPlugin.getDefault().getPreferenceStore()
+          .getBoolean(TestNGPluginConstants.S_PREFIX_VM_ARGS_FROM_POM_GLOBAL);
+    }
+    return Boolean.valueOf(prefixVmArgsFromPom);
   }
 
   public boolean getWatchResults(String projectName) {


### PR DESCRIPTION
since some people encounter issue with "Add the POM's JVM arguments when launching" enabled by default, so here is two things i made:
1. move the option to workspace and project level so that people can control it at workspace (globally) and/or project level
2. default to false (option 'Add the POM's JVM arguments when launching' unchecked at workspace level)

<img width="616" alt="argline" src="https://cloud.githubusercontent.com/assets/555134/11162497/a97a88d4-8a58-11e5-8424-3ca1f1ca0993.png">

@cbeust 
next step plan is, besides 'argLine', i'd like to add system properties and environment support, which mean add them to TestNG when launching.
to achieve this, i'd like to introduce an extension point in TestNG plugin, which defines the abstraction of testng launch configuration provider; Maven could be one implementation that append VM args, system properties and environment variable by parsing from the pom.xml; while Gradle could be the other implementation in feature. the whole point is to de-couple TestNG plugin with concrete implementation so that not hard-wire with specific plugin like m2e, etc.

anyway, this PR is a quick fix to solve the hot issue people suffered at the moment.