### PR TITLE
issue #42: option to disable/enable show the TestNG part name as the test suite name

### DIFF
--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGPluginConstants.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGPluginConstants.java
@@ -32,6 +32,7 @@ public abstract class TestNGPluginConstants {
   public static final String S_SUITE_METHOD_TREATMENT = "suiteMethodTreatment";
   public static final String S_PRE_DEFINED_LISTENERS = "preDefinedListeners";
   public static final String S_SHOW_VIEW_WHEN_TESTS_COMPLETE = "showViewWhenTestComplete";
+  public static final String S_VIEW_TITLE_SHOW_CASE_NAME = "showCaseNameOnViewTitle";
 
   private TestNGPluginConstants() {}
 }

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/TestRunnerViewPart.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/TestRunnerViewPart.java
@@ -540,10 +540,14 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
   }
 
   private void aboutToLaunch(final String message) {
-    String msg =
-      ResourceUtil.getFormattedString("TestRunnerViewPart.message.launching", message); //$NON-NLS-1$
-    setPartName(msg);
-    firePropertyChange(IWorkbenchPart.PROP_TITLE);
+    boolean showCaseName = TestNGPlugin.getDefault().getPreferenceStore()
+        .getBoolean(TestNGPluginConstants.S_VIEW_TITLE_SHOW_CASE_NAME);
+    if (showCaseName) {
+      String msg =
+        ResourceUtil.getFormattedString("TestRunnerViewPart.message.launching", message); //$NON-NLS-1$
+      setPartName(msg);
+      firePropertyChange(IWorkbenchPart.PROP_TITLE);
+    }
   }
 
   @Override

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/preferences/PreferenceInitializer.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/preferences/PreferenceInitializer.java
@@ -27,6 +27,8 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
     // tests finish running
     store.setDefault(TestNGPluginConstants.S_SHOW_VIEW_WHEN_TESTS_COMPLETE,
         true);
+    store.setDefault(TestNGPluginConstants.S_VIEW_TITLE_SHOW_CASE_NAME,
+        true);
     store.setDefault(TestNGPluginConstants.S_USEPROJECTJAR_GLOBAL, true);
   }
 

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/preferences/WorkspacePreferencePage.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/preferences/WorkspacePreferencePage.java
@@ -32,6 +32,7 @@ public class WorkspacePreferencePage
   private BooleanFieldEditor2 m_absolutePath;
   private BooleanFieldEditor2 m_disabledDefaultListeners;
   private BooleanFieldEditor2 m_showViewWhenTestsComplete;
+  private BooleanFieldEditor2 m_showCaseNameOnViewTitle;
   private BooleanFieldEditor2 m_useProjectJar;
   private FileFieldEditor m_xmlTemplateFile;
   private StringFieldEditor m_excludedStackTraces;
@@ -80,6 +81,11 @@ public class WorkspacePreferencePage
         "Show view when tests complete", //$NON-NLS-1$ 
         SWT.NONE, parentComposite);
 
+    m_showCaseNameOnViewTitle = new BooleanFieldEditor2(
+        TestNGPluginConstants.S_VIEW_TITLE_SHOW_CASE_NAME,
+        "Show test name on view title when tests complete", //$NON-NLS-1$ 
+        SWT.NONE, parentComposite);
+
     m_useProjectJar = new BooleanFieldEditor2(
         TestNGPluginConstants.S_USEPROJECTJAR_GLOBAL, 
         ResourceUtil.getString("TestNGPropertyPage.useProjectTestNGJar"), SWT.NONE, parentComposite);
@@ -108,6 +114,7 @@ public class WorkspacePreferencePage
     addField(m_absolutePath);
     addField(m_disabledDefaultListeners);
     addField(m_showViewWhenTestsComplete);
+    addField(m_showCaseNameOnViewTitle);
     addField(m_useProjectJar);
     addField(m_xmlTemplateFile);
     addField(m_excludedStackTraces);


### PR DESCRIPTION
since by default TestNG show the test case name when tests complete, but if the test case is so long that could level no space for the view toolbar, which make the view toolbar in a separate line, to me this just waste one line of space on the view:
<img width="1008" alt="testng_view_title" src="https://cloud.githubusercontent.com/assets/555134/11455062/2f0826da-95ff-11e5-9b49-a535ad7af64e.png">

to save the space, i leave an option for people to don't show the test case name on title so that it looks clean:
<img width="1083" alt="testng_view_title2" src="https://cloud.githubusercontent.com/assets/555134/11455073/522e30be-95ff-11e5-8913-f04e0e5fa891.png">

by default, it still shows test case name on view title just as its original behavior.