### PR TITLE
fixed issue #198

### DIFF
--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationDelegate.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/launch/TestNGLaunchConfigurationDelegate.java
@@ -378,12 +378,17 @@ public class TestNGLaunchConfigurationDelegate
     for (ITestNGLaunchConfigurationProvider lcp : TestNGPlugin
         .getLaunchConfigurationProviders()) {
       List<String> environs = lcp.getEnvironment(configuration);
-      if (environs != null) {
+      if (environs != null && environs.size() > 0) {
         result.addAll(environs);
       }
     }
 
-    return result.toArray(new String[] {});
+    if (result.isEmpty()) {
+      // fixed #198, return null rather than empty array
+      // see also: https://bugs.openjdk.java.net/browse/JDK-4902796
+      return null;
+    }
+    return result.toArray(new String[result.size()]);
   }
 
   private Version getRuntimeTestNGVersion(List<String> classpath)


### PR DESCRIPTION
well, looks like we went into this issue: https://bugs.openjdk.java.net/browse/JDK-4902796

if getEnvironments(ILaunchConfiguration launchConfig) returns an empty array rather than null, which is passed to java.lang.Runtime.exec(String[] cmdarray, String[] envp) that makes it confused.