### PR TITLE
feature #193: add project properties page

### DIFF
--- a/testng-maven-eclipse-plugin/plugin.xml
+++ b/testng-maven-eclipse-plugin/plugin.xml
@@ -24,5 +24,14 @@
              class="org.testng.eclipse.maven.MavenTestNGPreferenceInitializer">
        </initializer>
     </extension>
+    <extension
+          point="org.eclipse.ui.propertyPages">
+       <page
+             category="org.testng.eclipse.properties.propertyPage1"
+             class="org.testng.eclipse.maven.MavenTestNGPreferencePage"
+             id="org.testng.eclipse.maven.prop"
+             name="%org.testng.eclipse.maven.pref.name">
+       </page>
+    </extension>
 
 </plugin>

--- a/testng-maven-eclipse-plugin/src/org/testng/eclipse/maven/Activator.java
+++ b/testng-maven-eclipse-plugin/src/org/testng/eclipse/maven/Activator.java
@@ -12,7 +12,8 @@ public class Activator extends AbstractUIPlugin {
 
     // The plug-in ID
     public static final String PLUGIN_ID = "org.testng.eclipse.maven";
-    
+
+    public static final String PREF_USE_PROJECT_SETTINGS = "userprojectsettings";
     public static final String PREF_ARGLINE = PLUGIN_ID + ".argline";
     public static final String PREF_ENVIRON = PLUGIN_ID + ".environ";
     public static final String PREF_SYSPROPERTIES = PLUGIN_ID + ".sysproperties";

--- a/testng-maven-eclipse-plugin/src/org/testng/eclipse/maven/MavenTestNGOptionsConfigurationBlock.java
+++ b/testng-maven-eclipse-plugin/src/org/testng/eclipse/maven/MavenTestNGOptionsConfigurationBlock.java
@@ -21,7 +21,7 @@ public class MavenTestNGOptionsConfigurationBlock extends OptionsConfigurationBl
   private Button syspropsBtn;
 
   protected MavenTestNGOptionsConfigurationBlock(IProject project) {
-    super(project, getKeys());
+    super(project);
   }
 
   @Override
@@ -29,7 +29,7 @@ public class MavenTestNGOptionsConfigurationBlock extends OptionsConfigurationBl
     Composite composite = new Composite(parent, SWT.NONE);
     GridLayoutFactory.fillDefaults().applyTo(composite);
 
-    Group mavenGroup = new Group(composite, SWT.BORDER);
+    Group mavenGroup = new Group(composite, SWT.NONE);
     GridDataFactory.fillDefaults().grab(true, false).applyTo(mavenGroup);
     GridLayoutFactory.fillDefaults().applyTo(mavenGroup);
     mavenGroup.setText(Messages.prefPrefixFromPomGroupName);

--- a/testng-maven-eclipse-plugin/src/org/testng/eclipse/maven/MavenTestNGPreferencePage.java
+++ b/testng-maven-eclipse-plugin/src/org/testng/eclipse/maven/MavenTestNGPreferencePage.java
@@ -7,8 +7,8 @@ import org.eclipse.swt.widgets.Control;
 
 public class MavenTestNGPreferencePage extends PropertyAndPreferencePage {
 
-  private static final String PREF_ID = "org.testng.eclipse.maven.preferencePage"; //$NON-NLS-1$
-  private static final String PROP_ID = "org.testng.eclipse.maven.propertyPage"; //$NON-NLS-1$
+  private static final String PREF_ID = "org.testng.eclipse.maven.pref"; //$NON-NLS-1$
+  private static final String PROP_ID = "org.testng.eclipse.maven.prop"; //$NON-NLS-1$
 
   private MavenTestNGOptionsConfigurationBlock configBlock;
 
@@ -30,7 +30,15 @@ public class MavenTestNGPreferencePage extends PropertyAndPreferencePage {
 
   @Override
   protected boolean hasProjectSpecificOptions(IProject project) {
-    return false;
+    return configBlock.hasProjectSpecificOptions(project);
+  }
+
+  @Override
+  protected void enableProjectSpecificSettings(boolean useProjectSpecificSettings) {
+    super.enableProjectSpecificSettings(useProjectSpecificSettings);
+    if (configBlock != null) {
+      configBlock.useProjectSpecificSettings(useProjectSpecificSettings);
+    }
   }
 
   @Override

--- a/testng-maven-eclipse-plugin/src/org/testng/eclipse/maven/OptionsConfigurationBlock.java
+++ b/testng-maven-eclipse-plugin/src/org/testng/eclipse/maven/OptionsConfigurationBlock.java
@@ -2,7 +2,6 @@ package org.testng.eclipse.maven;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ProjectScope;
-import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.preferences.DefaultScope;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.IScopeContext;
@@ -73,11 +72,9 @@ public abstract class OptionsConfigurationBlock {
   private IScopeContext[] fLookupOrder;
 
   protected final IProject fProject;
-  protected final Key[] fAllKeys;
 
-  protected OptionsConfigurationBlock(IProject project, Key[] allKeys) {
+  protected OptionsConfigurationBlock(IProject project) {
     fProject = project;
-    fAllKeys = allKeys;
 
     if (fProject != null) {
       fLookupOrder = new IScopeContext[] { new ProjectScope(fProject), InstanceScope.INSTANCE, DefaultScope.INSTANCE };
@@ -110,17 +107,19 @@ public abstract class OptionsConfigurationBlock {
 
   public boolean hasProjectSpecificOptions(IProject project) {
     if (project != null) {
-      IScopeContext projectContext = new ProjectScope(project);
-      Key[] allKeys = fAllKeys;
-      Assert.isNotNull(allKeys);
-
-      for (int i = 0; i < allKeys.length; i++) {
-        if (allKeys[i].getStoredValue(projectContext) != null) {
-          return true;
-        }
+      String val = getValue(getKey(Activator.PREF_USE_PROJECT_SETTINGS));
+      if (val != null) {
+        return Boolean.parseBoolean(val);
       }
+      return false;
     }
     return false;
+  }
+
+  public void useProjectSpecificSettings(boolean useProjectSpecificSettings) {
+    if (fProject != null) {
+      setValue(getKey(Activator.PREF_USE_PROJECT_SETTINGS), useProjectSpecificSettings);
+    }
   }
 
   protected abstract Control createContents(Composite parent);

--- a/testng-maven-eclipse-plugin/src/org/testng/eclipse/maven/PreferenceUtils.java
+++ b/testng-maven-eclipse-plugin/src/org/testng/eclipse/maven/PreferenceUtils.java
@@ -1,16 +1,18 @@
 package org.testng.eclipse.maven;
 
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ProjectScope;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.DefaultScope;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.IPreferencesService;
+import org.eclipse.core.runtime.preferences.IScopeContext;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 
 public class PreferenceUtils {
 
   private final static IEclipsePreferences[] preferencesLookup = new IEclipsePreferences[] {
-      (InstanceScope.INSTANCE).getNode(Activator.PLUGIN_ID), 
-      (DefaultScope.INSTANCE).getNode(Activator.PLUGIN_ID) };
+      (InstanceScope.INSTANCE).getNode(Activator.PLUGIN_ID), (DefaultScope.INSTANCE).getNode(Activator.PLUGIN_ID) };
 
   /**
    * Get specific preference value in instance and default scope
@@ -19,18 +21,43 @@ public class PreferenceUtils {
    *          The preference key
    * @return
    */
-  public static String getString(String prefKey) {
+  public static String getString(IProject project, String prefKey) {
     IPreferencesService service = Platform.getPreferencesService();
-    String value = service.get(prefKey, null, preferencesLookup);
+    String value = service.get(prefKey, null, getPreferenceLookup(project));
     return value == null ? null : value.trim();
   }
 
-  public static boolean getBoolean(String prefKey) {
+  public static boolean getBoolean(IProject project, String prefKey) {
     IPreferencesService service = Platform.getPreferencesService();
-    String value = service.get(prefKey, null, preferencesLookup);
+    String value = service.get(prefKey, null, getPreferenceLookup(project));
     if (value != null) {
       return Boolean.parseBoolean(value);
     }
     return false;
+  }
+
+  private static IEclipsePreferences[] getPreferenceLookup(IProject project) {
+    IEclipsePreferences prjPref = null;
+    if (project != null) {
+      prjPref = getEclipsePreferences(project);
+    }
+
+    if (prjPref == null) {
+      return preferencesLookup;
+    }
+    if (!prjPref.getBoolean(Activator.PREF_USE_PROJECT_SETTINGS, false)) {
+      return preferencesLookup;
+    }
+
+    IEclipsePreferences[] prefs = new IEclipsePreferences[preferencesLookup.length + 1];
+    prefs[0] = prjPref;
+    System.arraycopy(preferencesLookup, 0, prefs, 1, preferencesLookup.length);
+    return prefs;
+  }
+
+  private static IEclipsePreferences getEclipsePreferences(IProject project) {
+    IScopeContext context = new ProjectScope(project);
+    IEclipsePreferences eclipsePreferences = context.getNode(Activator.PLUGIN_ID);
+    return eclipsePreferences;
   }
 }


### PR DESCRIPTION
now add the project level properties page, so that people can configure maven setting at project level (overriding the workspace level settings)
<img width="634" alt="testng_project_properties" src="https://cloud.githubusercontent.com/assets/555134/11556409/35d3ac28-995b-11e5-93eb-4da02b1dbd27.png">
