### PR TITLE
issue #203: Fix the phrasing of the Maven panel

### DIFF
--- a/testng-maven-eclipse-plugin/src/org/testng/eclipse/maven/Messages.properties
+++ b/testng-maven-eclipse-plugin/src/org/testng/eclipse/maven/Messages.properties
@@ -1,4 +1,4 @@
-prefPrefixFromPomGroupName=Pass to TestNG process following maven plugin configuration
+prefPrefixFromPomGroupName=Pass the following Maven configuration parameters to TestNG:
 prefArgLineBtnName=argLine
 prefSysPropsBtnName=systemPropertyVariables
 prefEnvironBtnName=environmentVariables


### PR DESCRIPTION
fixed #203 
<img width="631" alt="testng_phrasing" src="https://cloud.githubusercontent.com/assets/555134/11563285/0decb308-9988-11e5-8d02-60a8b3d1a1c5.png">
