### PR TITLE
[travis] Preserve Maven/Tycho cache between builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: java
+cache:
+  directories:
+  - $HOME/.m2
 
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
+sudo: false
 language: java
 
 jdk:
   - oraclejdk8
   - oraclejdk7
   - openjdk7
-
-


### PR DESCRIPTION
Reduce load on upstream servers by caching dependencies. To enable caching, Travis CI should be explicitly configured to use container-based infrastructure by disabling sudo.