### PR TITLE
feature #193: fixed testng maven does not respect maven-surefire-plugin rom build/plugins section

### DIFF
--- a/testng-maven-eclipse-plugin/src/org/testng/eclipse/maven/MavenTestNGLaunchConfigurationProvider.java
+++ b/testng-maven-eclipse-plugin/src/org/testng/eclipse/maven/MavenTestNGLaunchConfigurationProvider.java
@@ -160,18 +160,19 @@ public class MavenTestNGLaunchConfigurationProvider implements ITestNGLaunchConf
       return null;
     }
 
-    Xpp3Dom pluginConf = null;
-    List<Plugin> plugins;
+    // first, find from project plugins
+    List<Plugin> plugins = build.getPlugins();
+    Xpp3Dom pluginConf = findPluginConfiguration(plugins);
 
-    PluginManagement pluginMgnt = build.getPluginManagement();
-    if (pluginMgnt != null) {
-      plugins = pluginMgnt.getPlugins();
-      pluginConf = findPluginConfiguration(plugins);
-    }
+    // otherwise, find from project pluginManagement
     if (pluginConf == null) {
-      plugins = build.getPlugins();
-      pluginConf = findPluginConfiguration(plugins);
+      PluginManagement pluginMgnt = build.getPluginManagement();
+      if (pluginMgnt != null) {
+        plugins = pluginMgnt.getPlugins();
+        pluginConf = findPluginConfiguration(plugins);
+      }
     }
+
     return pluginConf;
   }
 


### PR DESCRIPTION
testng maven plugin found maven-surefire-plugin configuration in a wrong order, which find from build/pluginManagement/plugins first, but we should respect configuration under build/plugins first.