### PR TITLE
feature #229: publish snapshot to bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ cache:
   - $HOME/.m2
 
 jdk:
-  - oraclejdk8
   - oraclejdk7
-  - openjdk7
+
+script:
+  - mvn -e clean install
+
+after_success: test "${TRAVIS_PULL_REQUEST}" == "false" && ./scripts/upload-snapshot

--- a/scripts/pushToBintray.sh
+++ b/scripts/pushToBintray.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+#########################################################################################
+# copy from https://github.com/vogellacompany/bintray-publish-p2-updatesite
+#
+#Sample Usage: pushToBintray.sh username apikey owner repo package version pathToP2Repo
+#########################################################################################
+
+API=https://api.bintray.com
+BINTRAY_USER=$1
+BINTRAY_API_KEY=$2
+BINTRAY_OWNER=$3
+BINTRAY_REPO=$4
+PCK_NAME=$5
+PCK_VERSION=$6
+PATH_TO_REPOSITORY=$7
+
+function main() {
+deploy_updatesite
+}
+
+function deploy_updatesite() {
+echo "BINTRAY_USER=${BINTRAY_USER}"
+# echo "${BINTRAY_API_KEY}"
+echo "BINTRAY_OWNER=${BINTRAY_OWNER}"
+echo "BINTRAY_REPO=${BINTRAY_REPO}"
+echo "PCK_NAME=${PCK_NAME}"
+echo "PCK_VERSION=${PCK_VERSION}"
+echo "PATH_TO_REPOSITORY=${PATH_TO_REPOSITORY}"
+
+if [ ! -z "$PATH_TO_REPOSITORY" ]; then
+   cd $PATH_TO_REPOSITORY
+fi
+
+
+FILES=./*
+BINARYDIR=./binary/*
+PLUGINDIR=./plugins/*
+FEATUREDIR=./features/*
+
+for f in $FILES;
+do
+if [ ! -d $f ]; then
+  echo "Processing $f file..."
+  if [[ "$f" == *content.jar ]] || [[ "$f" == *artifacts.jar ]] 
+  then
+    echo "Uploading p2 metadata file directly to the repository"
+    curl -X PUT -T $f -u ${BINTRAY_USER}:${BINTRAY_API_KEY} https://api.bintray.com/content/${BINTRAY_OWNER}/${BINTRAY_REPO}/$f;publish=0
+  else 
+    curl -X PUT -T $f -u ${BINTRAY_USER}:${BINTRAY_API_KEY} https://api.bintray.com/content/${BINTRAY_OWNER}/${BINTRAY_REPO}/${PCK_NAME}/${PCK_VERSION}/$f;publish=0
+  fi
+  echo ""
+fi
+done
+
+echo "Processing features dir $FEATUREDIR file..."
+for f in $FEATUREDIR;
+do
+  echo "Processing feature: $f file..."
+  curl -X PUT -T $f -u ${BINTRAY_USER}:${BINTRAY_API_KEY} https://api.bintray.com/content/${BINTRAY_OWNER}/${BINTRAY_REPO}/${PCK_NAME}/${PCK_VERSION}/$f;publish=0
+  echo ""
+done
+
+echo "Processing plugin dir $PLUGINDIR file..."
+
+for f in $PLUGINDIR;
+do
+   # take action on each file. $f store current file name
+  echo "Processing plugin: $f file..."
+  curl -X PUT -T $f -u ${BINTRAY_USER}:${BINTRAY_API_KEY} https://api.bintray.com/content/${BINTRAY_OWNER}/${BINTRAY_REPO}/${PCK_NAME}/${PCK_VERSION}/$f;publish=0
+  echo ""
+done
+
+echo "Processing binary dir $BINARYDIR file..."
+if [ -d "$(dirname $BINARYDIR)" ]; then
+for f in $BINARYDIR;
+do
+   # take action on each file. $f store current file name
+  echo "Processing binary: $f file..."
+  curl -X PUT -T $f -u ${BINTRAY_USER}:${BINTRAY_API_KEY} https://api.bintray.com/content/${BINTRAY_OWNER}/${BINTRAY_REPO}/${PCK_NAME}/${PCK_VERSION}/$f;publish=0
+  echo ""
+done
+fi
+
+
+
+echo "Publishing the new version"
+curl -X POST -u ${BINTRAY_USER}:${BINTRAY_API_KEY} https://api.bintray.com/content/${BINTRAY_OWNER}/${BINTRAY_REPO}/${PCK_NAME}/${PCK_VERSION}/publish -d "{ \"discard\": \"false\" }"
+
+}
+
+
+main "$@"

--- a/scripts/upload-snapshot
+++ b/scripts/upload-snapshot
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# please don't share `~/.bintray.conf` to VCS since it must contain credentials as below:
+# BINTRAY_USER=xxx
+# BINTRAY_API_KEY=###
+if [ -f ~/.bintray.conf ]; then
+  . ~/.bintray.conf
+fi
+
+BINTRAY_USER=${BINTRAY_USER:?bintray user is not defined}
+BINTRAY_API_KEY=${BINTRAY_API_KEY:?bintray api key is not defined}
+BINTRAY_OWNER=${BINTRAY_OWNER:="testng-team"}
+BINTRAY_REPO=${BINTRAY_REPO:="testng-eclipse"}
+PCK_NAME=${PCK_NAME:="updatesite-beta"}
+PCK_VERSION=${PCK_VERSION:="latest"}
+
+base_dir=$(cd `dirname $0` && pwd)
+PATH_TO_REPOSITORY=$base_dir/../testng-eclipse-update-site/target/site
+
+if [ ! -d $PATH_TO_REPOSITORY ]; then
+  echo "the testng-eclipse update site $PATH_TO_REPOSITORY does not exist"
+  exit 1
+fi
+
+$base_dir/pushToBintray.sh "$BINTRAY_USER" "$BINTRAY_API_KEY" "$BINTRAY_OWNER" "$BINTRAY_REPO" "$PCK_NAME" "$PCK_VERSION" "$PATH_TO_REPOSITORY"


### PR DESCRIPTION
hi @cbeust 
PR for issue #229, please have a look at `scripts/upload-snapshot`, once it's OK, could you tune `new-release` (e.g. add -beta flag as command line argument) to call this script to publish snapshots to bintray

ping @juherr