### PR TITLE
feature #232: show plugin git revisions on system summary dialog

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ cache:
 jdk:
   - oraclejdk7
 
+before_install: echo "MAVEN_OPTS='-Xmx1024m -XX:MaxPermSize=512m'" > ~/.mavenrc
+
 script:
   - mvn -e clean install
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Supported Metrics:
   This should fix issue #91 thoroughly.
 * Issue #98: Rerun test method (declared in superclass) should use same class as before. (@aledsage)
 * Fix issue 70: isTest looks at superclass methods. (@aledsage)
+* Feature #232: show the git revision info the plugin being build against, for future diagnose purpose
 
 ## 6.9.10
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
->
+<project
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.testng.eclipse</groupId>
     <artifactId>org.testng.eclipse.parent</artifactId>
@@ -50,11 +50,11 @@
                     <resolver>p2</resolver>
                 </configuration>
             </plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-versions-plugin</artifactId>
-				<version>${tycho.version}</version>
-			</plugin>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-versions-plugin</artifactId>
+                <version>${tycho.version}</version>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>
@@ -81,6 +81,11 @@
                             <addMavenDescriptor>false</addMavenDescriptor>
                         </archive>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>pl.project13.maven</groupId>
+                    <artifactId>git-commit-id-plugin</artifactId>
+                    <version>2.2.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/testng-eclipse-plugin/plugin.xml
+++ b/testng-eclipse-plugin/plugin.xml
@@ -405,5 +405,13 @@ public void ${testName}() throws Exception {
        </pattern>
     </template>
  </extension>
+ <extension
+       point="org.eclipse.ui.systemSummarySections">
+    <section
+          class="org.testng.eclipse.SystemSummarySection"
+          id="org.testng.eclipse.SystemSummarySection"
+          sectionTitle="TestNG for Eclipse Details">
+    </section>
+ </extension>
 
 </plugin>

--- a/testng-eclipse-plugin/pom.xml
+++ b/testng-eclipse-plugin/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
->
+<project
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.testng.eclipse</groupId>
@@ -10,4 +10,33 @@
     </parent>
     <artifactId>org.testng.eclipse</artifactId>
     <packaging>eclipse-plugin</packaging>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>git.properties</include>
+                </includes>
+            </resource>
+        </resources>
+
+        <plugins>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <verbose>true</verbose>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/SystemSummarySection.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/SystemSummarySection.java
@@ -1,0 +1,30 @@
+package org.testng.eclipse;
+
+import java.io.PrintWriter;
+import java.net.URL;
+import java.util.Properties;
+
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.ui.about.ISystemSummarySection;
+import org.osgi.framework.Bundle;
+
+public class SystemSummarySection implements ISystemSummarySection {
+
+  @Override
+  public void write(PrintWriter writer) {
+    Bundle bundle = Platform.getBundle(TestNGPlugin.PLUGIN_ID);
+    URL fileURL = bundle.getEntry("git.properties");
+    if (fileURL == null) {
+      fileURL = this.getClass().getClassLoader().getResource("/git.properties");
+    }
+    Properties props = new Properties();
+    try {
+      props.load(fileURL.openStream());
+
+      props.list(writer);
+    } catch (Exception e) {
+      TestNGPlugin.log(e);
+    }
+  }
+
+}

--- a/testng-eclipse-plugin/src/main/resources/git.properties
+++ b/testng-eclipse-plugin/src/main/resources/git.properties
@@ -1,0 +1,3 @@
+git.branch=${git.branch}
+git.commit.id=${git.commit.id}
+git.build.version=${git.build.version}


### PR DESCRIPTION
for #232 

user can see the git revision info via "Help -> Installation Details -> switch to 'Configuration' tab":
<img width="643" alt="testng_sys_sum" src="https://cloud.githubusercontent.com/assets/555134/13351392/3f8d78de-dc3b-11e5-8f75-16bc4ef7c227.png">
