### PR TITLE
Issue #241 re-layout, to give more space to the testng result tree

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Supported Metrics:
 | TestNG for Eclipse | Eclipse Juno (4.2) or above |
 | TestNG M2E Integration (Optional) | M2E 1.5 or above |
 
+* enhancement #241: give more space to the testng result tree
 * issue #238: fixed the toolbar position on Eclipse Neon
 
 ## 6.9.11

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/CounterPanel.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/CounterPanel.java
@@ -51,8 +51,8 @@ public class CounterPanel extends Composite {
   protected int  m_methodCount = 0;
 
   public CounterPanel(Composite parent) {
-    super(parent, SWT.WRAP);
-    GridLayoutFactory.swtDefaults().margins(0, 0).spacing(0, 0).numColumns(3).applyTo(this);
+    super(parent, SWT.NONE);
+    GridLayoutFactory.swtDefaults().margins(0, 0).spacing(0, 0).applyTo(this);
 
     createReportUpperRow();
 
@@ -77,7 +77,7 @@ public class CounterPanel extends Composite {
     gridLayout.makeColumnsEqualWidth = true;
     gridLayout.marginWidth = 0;
     gridLayout.verticalSpacing= 0;
-    gridLayout.horizontalSpacing= 5;
+//    gridLayout.horizontalSpacing= 5;
     upperRow.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
     upperRow.setLayout(gridLayout);
 

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/TestRunnerViewPart.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/TestRunnerViewPart.java
@@ -894,6 +894,43 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
 
     {
       //
+      // Search
+      //
+      Composite m_searchComposite = new Composite(progressAndSearchComposite, SWT.NONE);
+      GridDataFactory.fillDefaults().grab(true, false).applyTo(m_searchComposite);
+      GridLayoutFactory.swtDefaults().numColumns(3).applyTo(m_searchComposite);
+
+      new Label(m_searchComposite, SWT.NONE).setText("Search:");
+      m_searchText = new Text(m_searchComposite, SWT.SINGLE | SWT.BORDER);
+      GridDataFactory.fillDefaults().align(SWT.FILL, SWT.CENTER).grab(true, false).applyTo(m_searchText);
+      m_searchText.addKeyListener(new KeyListener() {
+
+        public void keyPressed(KeyEvent e) {
+        }
+
+        public void keyReleased(KeyEvent e) {
+          if (currentSuiteRunInfo == null) {
+            return;
+          }
+          // Update the tree based on the search filter only if we don't have too many
+          // results, otherwise, wait for at least n characters to be typed.
+          String filter = "";
+          if (currentSuiteRunInfo.getNbResults() < MAX_RESULTS_THRESHOLD
+              || currentSuiteRunInfo.getNbResults() >= MAX_RESULTS_THRESHOLD
+              && m_searchText.getText().length() >= MAX_TEXT_SIZE_THRESHOLD) {
+            filter = m_searchText.getText();
+          }
+
+          for (TestRunTab tab : ALL_TABS) {
+            tab.updateSearchFilter(filter);
+          }
+        }
+
+      });
+    }
+
+    {
+      //
       // Progress bar
       //
       m_progressComposite = new Composite(progressAndSearchComposite, SWT.NONE);
@@ -929,43 +966,6 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
     // Counter panel
     //
     m_counterPanel = new CounterPanel(progressAndSearchComposite);
-
-    {
-      //
-      // Search
-      //
-      Composite m_searchComposite = new Composite(progressAndSearchComposite, SWT.NONE);
-      GridDataFactory.fillDefaults().grab(true, false).applyTo(m_searchComposite);
-      GridLayoutFactory.swtDefaults().numColumns(3).applyTo(m_searchComposite);
-
-      new Label(m_searchComposite, SWT.NONE).setText("Search:");
-      m_searchText = new Text(m_searchComposite, SWT.SINGLE | SWT.BORDER);
-      GridDataFactory.fillDefaults().align(SWT.FILL, SWT.CENTER).grab(true, false).applyTo(m_searchText);
-      m_searchText.addKeyListener(new KeyListener() {
-
-        public void keyPressed(KeyEvent e) {
-        }
-
-        public void keyReleased(KeyEvent e) {
-          if (currentSuiteRunInfo == null) {
-            return;
-          }
-          // Update the tree based on the search filter only if we don't have too many
-          // results, otherwise, wait for at least n characters to be typed.
-          String filter = "";
-          if (currentSuiteRunInfo.getNbResults() < MAX_RESULTS_THRESHOLD
-              || currentSuiteRunInfo.getNbResults() >= MAX_RESULTS_THRESHOLD
-              && m_searchText.getText().length() >= MAX_TEXT_SIZE_THRESHOLD) {
-            filter = m_searchText.getText();
-          }
-
-          for (TestRunTab tab : ALL_TABS) {
-            tab.updateSearchFilter(filter);
-          }
-        }
-
-      });
-    }
   }
 
   public IJavaProject getLaunchedProject() {

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/TestRunnerViewPart.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/TestRunnerViewPart.java
@@ -150,8 +150,9 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
    */
   private int fCurrentOrientation;
 
+  private Composite progressAndSearchComposite;
   private CounterPanel m_counterPanel;
-  private Composite m_counterComposite;
+  private Composite m_progressComposite;
 
   private final Image m_viewIcon = TestNGPlugin.getImageDescriptor("main16/testng_noshadow.gif").createImage();//$NON-NLS-1$
 
@@ -303,7 +304,7 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
     }
     fCurrentOrientation = orientation;
 
-    GridLayout layout = (GridLayout) m_counterComposite.getLayout();
+    GridLayout layout = (GridLayout) progressAndSearchComposite.getLayout();
 //    layout.numColumns = 1;
     setCounterColumns(layout);
 
@@ -450,7 +451,7 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
               postSyncRunnable(new Runnable() {
                 public void run() {
                   String suggestion = ResourceUtil.getString("TestRunnerViewPart.message.suggestion2");
-                   new ErrorDialog(m_counterComposite.getShell(),
+                   new ErrorDialog(m_progressComposite.getShell(),
                        "Couldn't launch TestNG", suggestion,
                        new Status(IStatus.ERROR, TestNGPlugin.PLUGIN_ID,
                            ResourceUtil.getString("TestRunnerViewPart.message.reason")),
@@ -883,9 +884,9 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
   }
 
   private void createProgressCountPanel(Composite parent) {
-    Composite c = new Composite(parent, SWT.NONE);
-    GridDataFactory.fillDefaults().grab(true, false).applyTo(c);
-    GridLayoutFactory.swtDefaults().applyTo(c);
+    progressAndSearchComposite = new Composite(parent, SWT.NONE);
+    GridDataFactory.fillDefaults().grab(true, false).applyTo(progressAndSearchComposite);
+    GridLayoutFactory.swtDefaults().margins(0, 0).spacing(0, 0).applyTo(progressAndSearchComposite);
 
     Display display= parent.getDisplay();
     fFailureColor= new Color(display, 159, 63, 63);
@@ -895,19 +896,17 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
       //
       // Progress bar
       //
-      m_counterComposite = new Composite(c, SWT.NONE);
-      GridDataFactory.fillDefaults().grab(true, false).applyTo(m_counterComposite);
-      GridLayout layout = new GridLayout();
-      setCounterColumns(layout);
-      GridLayoutFactory.createFrom(layout).margins(0, 0).spacing(5, 0).applyTo(m_counterComposite);
+      m_progressComposite = new Composite(progressAndSearchComposite, SWT.NONE);
+      GridDataFactory.fillDefaults().grab(true, false).applyTo(m_progressComposite);
+      GridLayoutFactory.swtDefaults().numColumns(2).applyTo(m_progressComposite);
 
-      fProgressBar = new ProgressBar(m_counterComposite);
+      fProgressBar = new ProgressBar(m_progressComposite);
       GridDataFactory.fillDefaults().grab(true, false).applyTo(fProgressBar);
 
       //
       // Stop button (a toolbar, actually)
       //
-      ToolBar toolBar = new ToolBar(m_counterComposite, SWT.FLAT);
+      ToolBar toolBar = new ToolBar(m_progressComposite, SWT.FLAT);
       GridDataFactory.swtDefaults().applyTo(toolBar);
       m_stopButton = new ToolItem(toolBar, SWT.PUSH);
       m_stopButton.setEnabled(false);
@@ -926,16 +925,21 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
       });
     }
 
+    //
+    // Counter panel
+    //
+    m_counterPanel = new CounterPanel(progressAndSearchComposite);
+
     {
       //
       // Search
       //
-      Composite line2 = new Composite(c, SWT.NONE);
-      GridDataFactory.fillDefaults().grab(true, false).applyTo(line2);
-      GridLayoutFactory.swtDefaults().margins(0, 0).spacing(5, 0).numColumns(3).applyTo(line2);
+      Composite m_searchComposite = new Composite(progressAndSearchComposite, SWT.NONE);
+      GridDataFactory.fillDefaults().grab(true, false).applyTo(m_searchComposite);
+      GridLayoutFactory.swtDefaults().numColumns(3).applyTo(m_searchComposite);
 
-      new Label(line2, SWT.NONE).setText("Search:");
-      m_searchText = new Text(line2, SWT.SINGLE | SWT.BORDER);
+      new Label(m_searchComposite, SWT.NONE).setText("Search:");
+      m_searchText = new Text(m_searchComposite, SWT.SINGLE | SWT.BORDER);
       GridDataFactory.fillDefaults().align(SWT.FILL, SWT.CENTER).grab(true, false).applyTo(m_searchText);
       m_searchText.addKeyListener(new KeyListener() {
 
@@ -961,11 +965,6 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
         }
 
       });
-
-      //
-      // Counter panel
-      //
-      m_counterPanel = new CounterPanel(line2);
     }
   }
 
@@ -1014,7 +1013,7 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
       layout.numColumns = 3;
     }
     else {
-      layout.numColumns = 2;
+      layout.numColumns = 1;
     }
   }
 

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/TestRunnerViewPart.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/TestRunnerViewPart.java
@@ -929,6 +929,11 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
       });
     }
 
+    //
+    // Counter panel
+    //
+    m_counterPanel = new CounterPanel(progressAndSearchComposite);
+
     {
       //
       // Progress bar
@@ -962,10 +967,6 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
       });
     }
 
-    //
-    // Counter panel
-    //
-    m_counterPanel = new CounterPanel(progressAndSearchComposite);
   }
 
   public IJavaProject getLaunchedProject() {


### PR DESCRIPTION
for #241 

### for horizontal orientation 

Before (the progress and counter line occupied two line):
<img width="996" alt="testng_h1" src="https://cloud.githubusercontent.com/assets/555134/14112231/bc787172-f582-11e5-90ce-b3dd5f6dd782.png">

After (make them onto the same line):
<img width="1024" alt="testng_h3" src="https://cloud.githubusercontent.com/assets/555134/14112263/dad7fd72-f582-11e5-97e1-1b5390e56d50.png">

### for vertical orientation

Before (the search text box is too small to use):
<img width="351" alt="testng_v1" src="https://cloud.githubusercontent.com/assets/555134/14112289/f5407cc0-f582-11e5-825a-cf349ae22447.png">

After (now we have three lines, the search has its own line):
<img width="340" alt="testng_v3" src="https://cloud.githubusercontent.com/assets/555134/14112304/0b98c5ea-f583-11e5-8865-8cf57dd0e341.png">
