### PR TITLE
fixed #251 Classes from WAR project exported with `<attachClasses>true</attachClasses>` are not visible

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Supported Metrics:
 * enhancement #241: give more space to the testng result tree
 * issue #238: fixed the toolbar position on Eclipse Neon
 * fixed issue #157: NPE in TestRunnerViewPart
+* fixed #251: Classes from WAR project exported with `<attachClasses>true</attachClasses>` are not visible
 
 ## 6.9.11
 

--- a/testng-maven-eclipse-plugin/META-INF/MANIFEST.MF
+++ b/testng-maven-eclipse-plugin/META-INF/MANIFEST.MF
@@ -12,12 +12,14 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.m2e.core;bundle-version="1.5.0",
  org.eclipse.m2e.maven.runtime;bundle-version="1.5.0",
  org.eclipse.m2e.profiles.core;bundle-version="1.5.0",
+ org.eclipse.m2e.jdt;bundle-version="1.5.0",
  org.eclipse.core.variables,
  org.eclipse.ui.console,
  org.eclipse.debug.core,
  org.eclipse.debug.ui,
  org.testng.eclipse;bundle-version="6.9.10",
  org.eclipse.jdt.core,
+ org.eclipse.jdt.launching,
  org.eclipse.jdt.ui
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/testng-maven-eclipse-plugin/plugin.xml
+++ b/testng-maven-eclipse-plugin/plugin.xml
@@ -33,5 +33,13 @@
              name="%org.testng.eclipse.maven.pref.name">
        </page>
     </extension>
+    <extension
+          point="org.eclipse.m2e.jdt.classifierClasspathProviders">
+       <classifierClasspathProvider
+             class="org.testng.eclipse.maven.WarClassesClassifierClasspathProvider"
+             id="org.testng.eclipse.maven.WarClassesClassifierClasspathProvider"
+             name="WarClassesClassifierClasspathProvider">
+       </classifierClasspathProvider>
+    </extension>
 
 </plugin>

--- a/testng-maven-eclipse-plugin/src/org/testng/eclipse/maven/WarClassesClassifierClasspathProvider.java
+++ b/testng-maven-eclipse-plugin/src/org/testng/eclipse/maven/WarClassesClassifierClasspathProvider.java
@@ -1,0 +1,41 @@
+package org.testng.eclipse.maven;
+
+import java.util.Set;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.launching.IRuntimeClasspathEntry;
+import org.eclipse.m2e.core.project.IMavenProjectFacade;
+import org.eclipse.m2e.jdt.AbstractClassifierClasspathProvider;
+
+public class WarClassesClassifierClasspathProvider extends AbstractClassifierClasspathProvider {
+
+  @Override
+  public boolean applies(IMavenProjectFacade mavenProjectFacade, String classifier) {
+    return getClassifier().equals(classifier);
+  }
+
+  @Override
+  public String getClassifier() {
+    return "classes";
+  }
+
+  /**
+   * Adds the main classes folder to the runtime classpath.
+   */
+  @Override
+  public void setRuntimeClasspath(Set<IRuntimeClasspathEntry> runtimeClasspath, IMavenProjectFacade mavenProjectFacade,
+      IProgressMonitor monitor) throws CoreException {
+    addMainFolder(runtimeClasspath, mavenProjectFacade, monitor);
+  }
+
+  /**
+   * Adds the main classes folder to the test classpath.
+   */
+  @Override
+  public void setTestClasspath(Set<IRuntimeClasspathEntry> testClasspath, IMavenProjectFacade mavenProjectFacade,
+      IProgressMonitor monitor) throws CoreException {
+    setRuntimeClasspath(testClasspath, mavenProjectFacade, monitor);
+  }
+
+}


### PR DESCRIPTION
fix #251 
there is [relate](https://bugs.eclipse.org/bugs/show_bug.cgi?id=368230#c13) [ticket](https://bugs.eclipse.org/bugs/show_bug.cgi?id=368230) at M2E

> 3rd party plugins can implement the IClassifierClasspathProvider interface, or rather extend AbstractClassifierClasspathProvider and provide appropriate test or runtime classpath for a given classifier.
By default, unknown classifiers fall back a NO-OP IClassifierClasspathProvider implementation, to match existing m2e behaviour.

so my fix is registering a new `IClassifierClasspathProvider` for classifier `classes`. this one will impact all  maven projects with dependencies of classifier `classes`