### PR TITLE
fixed #273: Not able to create a test with the default package

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Supported Metrics:
 * fixed issue #129: Results View not synchronizing properly
 * https://github.com/testng-team/testng-remote/issues/33: add support for TestNG versions in [6.0, 6.5.1)
 * fixed https://github.com/cbeust/testng/issues/455: Optional parameter is not initialized properly
+* fixed #273: Not able to create a test with the default package
 
 ## 6.9.12
 

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/wizards/NewTestNGClassWizard.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/wizards/NewTestNGClassWizard.java
@@ -213,23 +213,24 @@ public class NewTestNGClassWizard extends Wizard implements INewWizard {
           + "  }\n");
     }
 
-    String contents =
-	      "package " + m_page.getPackage() + ";\n\n"
-	      + imports
-	      + "\n"
-	      + "public class " + className + " {\n"
-	      ;
-
-    if (testMethods.size() == 0 || ! StringUtils.isEmptyString(dataProvider)) {
-      contents +=
-          "  @Test" + dataProvider + "\n"
-  	      + "  public void f" + signature + " {\n"
-  	      + "  }\n";
+    StringBuilder contents = new StringBuilder();
+    if (!StringUtils.isEmptyString(m_page.getPackageName())) {
+      contents.append("package " + m_page.getPackageName() + ";\n\n");
     }
 
-    contents += methods + "}\n";
+    contents.append(imports).append("\n");
+    contents.append("public class " + className + " {\n");
 
-	  return new ByteArrayInputStream(contents.getBytes());
+    if (testMethods.size() == 0 || ! StringUtils.isEmptyString(dataProvider)) {
+      contents.append(
+          "  @Test" + dataProvider + "\n"
+  	      + "  public void f" + signature + " {\n"
+  	      + "  }\n");
+    }
+
+    contents.append(methods + "}\n");
+
+	  return new ByteArrayInputStream(contents.toString().getBytes());
 	}
 
 	/**

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/wizards/NewTestNGClassWizardPage.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/wizards/NewTestNGClassWizardPage.java
@@ -35,6 +35,10 @@ import java.util.List;
 import java.util.Map;
 
 /**
+ * TODO refactor by extending org.eclipse.jdt.ui.wizards.NewTypeWizardPage, 
+ *      see org.eclipse.jdt.junit.wizards.NewTestCaseWizardPageOne
+ * 
+ *
  * Generate a new TestNG class and optionally, the corresponding XML suite file.
  */
 public class NewTestNGClassWizardPage extends WizardPage {
@@ -232,11 +236,11 @@ public class NewTestNGClassWizardPage extends WizardPage {
     if (container.getProject() == null || container.getProject().getName() == null || container.getProject().getName().length() == 0) {
       updateStatus("The source folder of an existing project must be specified.");
       return;
-    }    
-    if (getPackageName().length() == 0) {
-      updateStatus("The package must be specified");
-      return;
     }
+//    if (getPackageName().length() == 0) {
+//      updateStatus("The package must be specified");
+//      return;
+//    }
     if (container != null && !container.isAccessible()) {
       updateStatus("Project must be writable");
       return;
@@ -285,9 +289,5 @@ public class NewTestNGClassWizardPage extends WizardPage {
   public boolean containsAnnotation(String annotation) {
     Button b = m_annotations.get(annotation);
     return b.getSelection();
-  }
-
-  public String getPackage() {
-    return m_packageNameText.getText();
   }
 }


### PR DESCRIPTION
for #273 

side notes, this PR is just a quick and dirty way to allow use the default package (aka, without specifying the package name).
however, for the sake of reusing existing JDT code, the class [NewTestNGClassWizardPage](https://github.com/cbeust/testng-eclipse/blob/master/testng-eclipse-plugin/src/main/org/testng/eclipse/wizards/NewTestNGClassWizardPage.java) need to be refactoring by extending `org.eclipse.jdt.ui.wizards.NewTypeWizardPage` in future, see also `org.eclipse.jdt.junit.wizards.NewTestCaseWizardPageOne`. in this way, it will add more validation on package and class name, also provides content assistant support for the fields.