### PR TITLE
enable systemProperties and environmentVariables by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Supported Metrics:
 * fixed https://github.com/cbeust/testng/issues/455: Optional parameter is not initialized properly
 * fixed #273: Not able to create a test with the default package
 * https://github.com/testng-team/testng-remote/issues/36: Support DEV-SNAPSHOT version
+* #284: for 2e integration, enable parsing systemProperties and environmentVariables by default. and fix a potential NPE if 'environmentVariables' not present in pom.xml
 
 ## 6.9.12
 

--- a/testng-maven-eclipse-plugin/src/org/testng/eclipse/maven/MavenTestNGLaunchConfigurationProvider.java
+++ b/testng-maven-eclipse-plugin/src/org/testng/eclipse/maven/MavenTestNGLaunchConfigurationProvider.java
@@ -66,11 +66,13 @@ public class MavenTestNGLaunchConfigurationProvider implements ITestNGLaunchConf
     if (confDom != null) {
       if (PreferenceUtils.getBoolean(project, Activator.PREF_ENVIRON)) {
         Xpp3Dom envDom = confDom.getChild("environmentVariables");
-        List<String> environList = new ArrayList<>(envDom.getChildCount());
-        for (Xpp3Dom varDom : envDom.getChildren()) {
-          environList.add(varDom.getName() + "=" + varDom.getValue());
+        if (envDom != null) {
+          List<String> environList = new ArrayList<>(envDom.getChildCount());
+          for (Xpp3Dom varDom : envDom.getChildren()) {
+            environList.add(varDom.getName() + "=" + varDom.getValue());
+          }
+          return environList;
         }
-        return environList;
       }
     }
     return null;

--- a/testng-maven-eclipse-plugin/src/org/testng/eclipse/maven/MavenTestNGPreferenceInitializer.java
+++ b/testng-maven-eclipse-plugin/src/org/testng/eclipse/maven/MavenTestNGPreferenceInitializer.java
@@ -14,6 +14,8 @@ public class MavenTestNGPreferenceInitializer extends AbstractPreferenceInitiali
   public void initializeDefaultPreferences() {
     Map<String, String> defaultMap = new HashMap<>();
     defaultMap.put(Activator.PREF_ARGLINE, Boolean.TRUE.toString());
+    defaultMap.put(Activator.PREF_SYSPROPERTIES, Boolean.TRUE.toString());
+    defaultMap.put(Activator.PREF_ENVIRON, Boolean.TRUE.toString());
 
     // Store default values to default core preferences
     IEclipsePreferences defaultPreferences = DefaultScope.INSTANCE.getNode(Activator.PLUGIN_ID);


### PR DESCRIPTION
for #284, now enable parsing `systemProperties` and `environmentVariables` by default, and append to runtime testng process.