### PR TITLE
#102 relative location for template file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Supported Metrics:
 * fixed #301: UI typo: Serilization -> Serialization
 * feature #300: testng eclipse plugin results view should allow the user to copy the test data that is displayed for test iterations
 * fixed #279: java.lang.SecurityException: class "org.osgi.framework.BundleException"'s signer information does not match signer information of other classes in the same package
+* feature #102: Template XML file should should offer workspace-related location
 
 ## 6.10
 

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGMessages.properties
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGMessages.properties
@@ -134,6 +134,8 @@ TestNGPropertyPage.outputDir=Output directory:
 TestNGPropertyPage.templateXml=Template XML file:
 TestNGPropertyPage.watchResultXml=Watch testng-results.xml
 TestNGPropertyPage.resultXmlDirectory=Directory:
+TestNGPropertyPage.disableDefaultListeners=Disable default listeners
+TestNGPropertyPage.disableDefaultListeners.tips=Split multi listener using ';'
 TestNGPropertyPage.preDefinedListeners=Pre Defined Listeners:
 
 

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/preferences/ProjectPropertyPage.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/preferences/ProjectPropertyPage.java
@@ -30,8 +30,8 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.DirectoryDialog;
-import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.dialogs.ISelectionStatusValidator;
 import org.eclipse.ui.dialogs.PropertyPage;
@@ -100,6 +100,44 @@ public class ProjectPropertyPage extends PropertyPage {
     }
 
     //
+    // XML template file
+    //
+
+    {
+      SelectionAdapter buttonListener = new SelectionAdapter() {
+        public void widgetSelected(SelectionEvent evt) {
+          String result = Utils.selectTemplateFile(getShell());
+          if (result != null) {
+            m_xmlTemplateFile.setText(result);
+          }
+        }
+      };
+      Widgets w = Utils.createTextBrowseControl(parentComposite, null,
+          "TestNGPropertyPage.templateXml", buttonListener, null, null, true);
+      m_xmlTemplateFile = w.text;
+
+    }
+
+    //
+    // Disable default listeners
+    //
+    m_disabledDefaultListeners = new Button(parentComposite, SWT.CHECK);
+    m_disabledDefaultListeners.setText(ResourceUtil.getString("TestNGPropertyPage.disableDefaultListeners"));
+//    m_disabledDefaultListeners.setLayoutData(SWTUtil.createGridData());//new GridData(SWT.FILL, SWT.NONE, true, false, 4, 1));
+//    m_disabledDefaultListeners.setBackground(new Color(parent.getDisplay(), 0xcc, 0, 0));
+
+
+    //Create a string editor control: A label and a text area
+    {
+      Widgets w = Utils.createStringEditorControl(parentComposite, "TestNGPropertyPage.preDefinedListeners", null, true);
+      m_preDefinedListeners = w.text;
+      m_preDefinedListeners.setToolTipText(ResourceUtil.getString("TestNGPropertyPage.disableDefaultListeners.tips"));
+    }
+
+    Label sepLabel = new Label(parentComposite, SWT.SEPARATOR | SWT.HORIZONTAL);
+    GridDataFactory.fillDefaults().applyTo(sepLabel);
+
+    //
     // Watch testng-results.xml
     //
     {
@@ -128,42 +166,6 @@ public class ProjectPropertyPage extends PropertyPage {
       m_watchResultRadio = w.radio;
     }
 
-    //
-    // XML template file
-    //
-
-    {
-      SelectionAdapter buttonListener = new SelectionAdapter() {
-        public void widgetSelected(SelectionEvent evt) {
-          FileDialog dlg= new FileDialog(m_xmlTemplateFile.getShell());
-          dlg.setText("Select Template XML file");
-          String[] filterExt = {"*.xml"};
-          dlg.setFilterExtensions(filterExt);
-          String selectedFile= dlg.open();
-          m_xmlTemplateFile.setText(selectedFile != null ? selectedFile : "");
-        }
-      };
-      Widgets w = Utils.createTextBrowseControl(parentComposite, null,
-          "TestNGPropertyPage.templateXml", buttonListener, null, null, true);
-      m_xmlTemplateFile = w.text;
-
-    }
-
-    //
-    // Disable default listeners
-    //
-    m_disabledDefaultListeners = new Button(parentComposite, SWT.CHECK);
-    m_disabledDefaultListeners.setText(ResourceUtil.getString("TestNGPropertyPage.disableDefaultListeners"));
-//    m_disabledDefaultListeners.setLayoutData(SWTUtil.createGridData());//new GridData(SWT.FILL, SWT.NONE, true, false, 4, 1));
-//    m_disabledDefaultListeners.setBackground(new Color(parent.getDisplay(), 0xcc, 0, 0));
-
-    
-    //Create a string editor control: A label and a text area
-    {
-      Widgets w = Utils.createStringEditorControl(parentComposite, "TestNGPropertyPage.preDefinedListeners", null, true);
-      m_preDefinedListeners = w.text;
-      m_preDefinedListeners.setToolTipText(ResourceUtil.getString("TestNGPropertyPage.disableDefaultListeners.tips"));
-    }
     loadDefaults();
 
     return parentComposite;

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/preferences/ProjectPropertyPage.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/preferences/ProjectPropertyPage.java
@@ -42,6 +42,7 @@ import org.testng.eclipse.ui.util.Utils;
 import org.testng.eclipse.ui.util.Utils.Widgets;
 import org.testng.eclipse.util.JDTUtil;
 import org.testng.eclipse.util.PreferenceStoreUtil;
+import org.testng.eclipse.util.ResourceUtil;
 import org.testng.eclipse.util.SWTUtil;
 import org.testng.reporters.XMLReporter;
 
@@ -152,7 +153,7 @@ public class ProjectPropertyPage extends PropertyPage {
     // Disable default listeners
     //
     m_disabledDefaultListeners = new Button(parentComposite, SWT.CHECK);
-    m_disabledDefaultListeners.setText("Disable default listeners");
+    m_disabledDefaultListeners.setText(ResourceUtil.getString("TestNGPropertyPage.disableDefaultListeners"));
 //    m_disabledDefaultListeners.setLayoutData(SWTUtil.createGridData());//new GridData(SWT.FILL, SWT.NONE, true, false, 4, 1));
 //    m_disabledDefaultListeners.setBackground(new Color(parent.getDisplay(), 0xcc, 0, 0));
 
@@ -161,7 +162,7 @@ public class ProjectPropertyPage extends PropertyPage {
     {
       Widgets w = Utils.createStringEditorControl(parentComposite, "TestNGPropertyPage.preDefinedListeners", null, true);
       m_preDefinedListeners = w.text;
-      m_preDefinedListeners.setToolTipText("Split multi listener using ;");
+      m_preDefinedListeners.setToolTipText(ResourceUtil.getString("TestNGPropertyPage.disableDefaultListeners.tips"));
     }
     loadDefaults();
 

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/preferences/WorkspacePreferencePage.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/preferences/WorkspacePreferencePage.java
@@ -7,7 +7,6 @@ import org.eclipse.debug.internal.ui.preferences.BooleanFieldEditor2;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.preference.DirectoryFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
-import org.eclipse.jface.preference.FileFieldEditor;
 import org.eclipse.jface.preference.StringButtonFieldEditor;
 import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.swt.SWT;
@@ -20,6 +19,7 @@ import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.testng.eclipse.TestNGPlugin;
 import org.testng.eclipse.TestNGPluginConstants;
+import org.testng.eclipse.ui.util.Utils;
 import org.testng.eclipse.util.ResourceUtil;
 
 /**
@@ -34,7 +34,7 @@ public class WorkspacePreferencePage
   private BooleanFieldEditor2 m_disabledDefaultListeners;
   private BooleanFieldEditor2 m_showViewWhenTestsComplete;
   private BooleanFieldEditor2 m_showCaseNameOnViewTitle;
-  private FileFieldEditor m_xmlTemplateFile;
+  private ResourceSelectionFieldEditor m_xmlTemplateFile;
   private StringFieldEditor m_excludedStackTraces;
   private StringFieldEditor m_preDefinedListeners;
   
@@ -72,10 +72,8 @@ public class WorkspacePreferencePage
     m_outputdir.setAbsolutePathVerifier(m_absolutePath);
 
     // XML template
-    m_xmlTemplateFile = new FileFieldEditor(TestNGPluginConstants.S_XML_TEMPLATE_FILE,
-        ResourceUtil.getString("TestNGPropertyPage.templateXml"), false /* no absolute */,
-        StringButtonFieldEditor.VALIDATE_ON_FOCUS_LOST,
-        parentComposite);
+    m_xmlTemplateFile = new ResourceSelectionFieldEditor(TestNGPluginConstants.S_XML_TEMPLATE_FILE,
+        ResourceUtil.getString("TestNGPropertyPage.templateXml"), parentComposite);
     m_xmlTemplateFile.setEmptyStringAllowed(true);
     m_xmlTemplateFile.fillIntoGrid(parentComposite, 3);
 
@@ -125,6 +123,19 @@ public class WorkspacePreferencePage
    * @see org.eclipse.ui.IWorkbenchPreferencePage#init(org.eclipse.ui.IWorkbench)
    */
   public void init(IWorkbench workbench) {
+  }
+
+  private static class ResourceSelectionFieldEditor extends StringButtonFieldEditor {
+
+    public ResourceSelectionFieldEditor(String name, String labelText, Composite parent) {
+      super(name, labelText, parent);
+      setChangeButtonText("Browse...");
+    }
+
+    @Override
+    protected String changePressed() {
+      return Utils.selectTemplateFile(getShell());
+    }
   }
 
   private static class FSBrowseDirectoryFieldEditor extends DirectoryFieldEditor {

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/preferences/WorkspacePreferencePage.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/preferences/WorkspacePreferencePage.java
@@ -15,10 +15,12 @@ import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.testng.eclipse.TestNGPlugin;
 import org.testng.eclipse.TestNGPluginConstants;
+import org.testng.eclipse.util.ResourceUtil;
 
 /**
  * Workspace wide preferences for TestNG.
@@ -69,24 +71,9 @@ public class WorkspacePreferencePage
         parentComposite); 
     m_outputdir.setAbsolutePathVerifier(m_absolutePath);
 
-    m_disabledDefaultListeners= new BooleanFieldEditor2(TestNGPluginConstants.S_DISABLEDLISTENERS, 
-        "Disable default listeners", //$NON-NLS-1$ 
-        SWT.NONE, 
-        parentComposite);
-
-    m_showViewWhenTestsComplete = new BooleanFieldEditor2(
-        TestNGPluginConstants.S_SHOW_VIEW_WHEN_TESTS_COMPLETE,
-        "Show view when tests complete", //$NON-NLS-1$ 
-        SWT.NONE, parentComposite);
-
-    m_showCaseNameOnViewTitle = new BooleanFieldEditor2(
-        TestNGPluginConstants.S_VIEW_TITLE_SHOW_CASE_NAME,
-        "Show test name on view title when tests complete", //$NON-NLS-1$ 
-        SWT.NONE, parentComposite);
-
     // XML template
     m_xmlTemplateFile = new FileFieldEditor(TestNGPluginConstants.S_XML_TEMPLATE_FILE,
-        "Template XML file:", false /* no absolute */,
+        ResourceUtil.getString("TestNGPropertyPage.templateXml"), false /* no absolute */,
         StringButtonFieldEditor.VALIDATE_ON_FOCUS_LOST,
         parentComposite);
     m_xmlTemplateFile.setEmptyStringAllowed(true);
@@ -100,10 +87,30 @@ public class WorkspacePreferencePage
         .hint(convertWidthInCharsToPixels(36), SWT.DEFAULT)
         .applyTo(m_excludedStackTraces.getTextControl(parentComposite));
 
+
+    m_disabledDefaultListeners= new BooleanFieldEditor2(TestNGPluginConstants.S_DISABLEDLISTENERS, 
+        ResourceUtil.getString("TestNGPropertyPage.disableDefaultListeners"), //$NON-NLS-1$ 
+        SWT.NONE, 
+        parentComposite);
+
     m_preDefinedListeners = new StringFieldEditor(TestNGPluginConstants.S_PRE_DEFINED_LISTENERS,
-        "Pre Defined Listeners", parentComposite);
-    
-    
+        ResourceUtil.getString("TestNGPropertyPage.preDefinedListeners"), parentComposite);
+
+
+    Label sepLabel = new Label(parentComposite, SWT.SEPARATOR | SWT.HORIZONTAL);
+    GridDataFactory.fillDefaults().span(3, SWT.DEFAULT).applyTo(sepLabel);
+
+    m_showViewWhenTestsComplete = new BooleanFieldEditor2(
+        TestNGPluginConstants.S_SHOW_VIEW_WHEN_TESTS_COMPLETE,
+        "Show view when tests complete", //$NON-NLS-1$ 
+        SWT.NONE, parentComposite);
+
+    m_showCaseNameOnViewTitle = new BooleanFieldEditor2(
+        TestNGPluginConstants.S_VIEW_TITLE_SHOW_CASE_NAME,
+        "Show test name on view title when tests complete", //$NON-NLS-1$ 
+        SWT.NONE, parentComposite);
+
+
     addField(m_outputdir);
     addField(m_absolutePath);
     addField(m_disabledDefaultListeners);

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/util/CustomSuite.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/util/CustomSuite.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.core.variables.IStringVariableManager;
 import org.eclipse.core.variables.VariablesPlugin;
 import org.testng.TestNGException;
@@ -53,6 +54,7 @@ abstract public class CustomSuite extends LaunchSuite {
   protected String m_suiteName;
   protected Map<String, String> m_parameters;
   protected int m_logLevel;
+  private String workingDir;
 
   private XMLStringBuffer m_suiteBuffer;
 //  private List<String> m_suiteFiles;
@@ -66,10 +68,12 @@ abstract public class CustomSuite extends LaunchSuite {
   public CustomSuite(final String projectName,
                      final String suiteName,
                      final Map<String, String> parameters,
-                     final int logLevel) {
+                     final int logLevel,
+                     final String workingDir) {
     super(true);
     init(Collections.<String>emptyList(), projectName, suiteName, parameters,
         logLevel);
+    this.workingDir = workingDir;
   }
 
   private void init(List<String> suiteFiles, String projectName,
@@ -106,7 +110,13 @@ abstract public class CustomSuite extends LaunchSuite {
 
     if (hasEclipseXmlFile) {
       try {
-        createXmlFileFromTemplate(suiteBuffer, xmlFile);
+        IStringVariableManager manager = VariablesPlugin.getDefault().getStringVariableManager();
+        String resolvedXmlFile = manager.performStringSubstitution(xmlFile);
+        if (!(new Path(resolvedXmlFile).isAbsolute()) && !Utils.isStringEmpty(workingDir)) {
+          resolvedXmlFile = workingDir + "/" + resolvedXmlFile;
+        }
+
+        createXmlFileFromTemplate(suiteBuffer, resolvedXmlFile);
       } catch (CoreException e) {
         TestNGPlugin.log(e);
       }
@@ -155,9 +165,7 @@ abstract public class CustomSuite extends LaunchSuite {
    */
   private void createXmlFileFromTemplate(XMLStringBuffer suiteBuffer, String fileName) throws CoreException {
     try {
-      IStringVariableManager manager = VariablesPlugin.getDefault().getStringVariableManager();
-      String resolvedFileName = manager.performStringSubstitution(fileName);
-      Parser parser = new Parser(resolvedFileName);
+      Parser parser = new Parser(fileName);
       parser.setLoadClasses(false); // we don't want to load the classes from the template file
       Collection<XmlSuite> suites = parser.parse();
       if (suites.size() > 0) {
@@ -383,8 +391,9 @@ class ClassMethodsSuite extends CustomSuite {
                            final List<String> classNames,
                            final Map<String, List<String>> classMethods,
                            final Map<String, String> parameters,
-                           final int logLevel) {
-    super(projectName, DEFAULT_SUITE_TAG_NAME, parameters, logLevel);
+                           final int logLevel,
+                           final String workingDir) {
+    super(projectName, DEFAULT_SUITE_TAG_NAME, parameters, logLevel, workingDir);
     m_classNames = classNames;
     m_classMethods = classMethods != null ? sanitize(classMethods): classMethods;
     if(m_useMethods) {
@@ -478,8 +487,9 @@ class GroupListSuite extends CustomSuite {
                         final List<String> classNames,
                         final List<String> groupNames,
                         final Map<String, String> parameters,
-                        final int logLevel) {
-    super(projectName, projectName + " by groups", parameters, logLevel);
+                        final int logLevel,
+                        final String workingDir) {
+    super(projectName, projectName + " by groups", parameters, logLevel, workingDir);
 
     m_packageNames= packageNames;
     m_classNames= classNames;
@@ -523,8 +533,9 @@ class PackageSuite extends CustomSuite {
   public PackageSuite(final String projectName,
                       final List<String> packageNames,
                       final Map<String, String> parameters,
-                      final int logLevel) {
-    super(projectName, projectName + " by packages", parameters, logLevel);
+                      final int logLevel,
+                      final String workingDir) {
+    super(projectName, projectName + " by packages", parameters, logLevel, workingDir);
     m_packageNames= packageNames;
   }
 

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/util/SuiteGenerator.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/util/SuiteGenerator.java
@@ -21,18 +21,18 @@ public class SuiteGenerator {
   public static LaunchSuite createCustomizedSuite(String projectName,
       List<String> packageNames, List<String> classNames, Map<String, List<String>> methodNames,
       List<String> groupNames, Map<String, String> parameters,
-      int logLevel) {
+      int logLevel, String workingDir) {
 
     if((null != groupNames) && !groupNames.isEmpty()) {
       return new GroupListSuite(projectName, packageNames, classNames, groupNames, parameters,
-          logLevel);
+          logLevel, workingDir);
     }
     else if(null != packageNames && !packageNames.isEmpty()) {
-      return new PackageSuite(projectName, packageNames, parameters, logLevel);
+      return new PackageSuite(projectName, packageNames, parameters, logLevel, workingDir);
     }
     else {
       return new ClassMethodsSuite(projectName, classNames, methodNames, parameters,
-          logLevel);
+          logLevel, workingDir);
     }
   }
 


### PR DESCRIPTION
for #102.

from now on, people can only browse the template file in the workspace, but the template file text field is editable, that both absolute and relative path is supported.

also, in this PR, slight re-group some relate configuration together:
Before:
<img width="846" alt="screenshot at jan 27 06-43-18" src="https://cloud.githubusercontent.com/assets/555134/22393949/a9af55bc-e4c7-11e6-8d1e-da0c41cad5db.png">

After:
<img width="695" alt="screenshot at jan 27 06-42-09" src="https://cloud.githubusercontent.com/assets/555134/22393953/ba618d6c-e4c7-11e6-83bb-e4b545350754.png">

