### PR TITLE
Update build machinery to latest version of tycho

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,9 @@
     <packaging>pom</packaging>
 
     <properties>
-        <tycho.version>0.24.0</tycho.version>
+        <tycho.version>1.0.0</tycho.version>
         <enforcer.maven.version>3.1.1</enforcer.maven.version>
-        <enforcer.java.version>1.7</enforcer.java.version>
+        <enforcer.java.version>1.8</enforcer.java.version>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -49,7 +49,33 @@
                 <artifactId>target-platform-configuration</artifactId>
                 <version>${tycho.version}</version>
                 <configuration>
-                    <resolver>p2</resolver>
+                  <environments>
+                    <environment>
+                      <os>win32</os>
+                      <ws>win32</ws>
+                      <arch>x86</arch>
+                    </environment>
+                    <environment>
+                      <os>win32</os>
+                      <ws>win32</ws>
+                      <arch>x86_64</arch>
+                    </environment>
+                    <environment>
+                      <os>linux</os>
+                      <ws>gtk</ws>
+                      <arch>x86</arch>
+                    </environment>
+                    <environment>
+                      <os>linux</os>
+                      <ws>gtk</ws>
+                      <arch>x86_64</arch>
+                    </environment>
+                    <environment>
+                      <os>macosx</os>
+                      <ws>cocoa</ws>
+                      <arch>x86_64</arch>
+                    </environment>
+                  </environments>
                 </configuration>
             </plugin>
             <plugin>
@@ -62,7 +88,9 @@
                 <artifactId>tycho-packaging-plugin</artifactId>
                 <version>${tycho.version}</version>
                 <configuration>
-                    <archiveSite>true</archiveSite>
+                    <archive>
+                        <addMavenDescriptor>false</addMavenDescriptor>
+                    </archive>
                 </configuration>
             </plugin>
             <plugin>
@@ -93,30 +121,6 @@
         </plugins>
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.6</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.tycho</groupId>
-                    <artifactId>maven-osgi-packaging-plugin</artifactId>
-                    <version>${tycho.version}</version>
-                    <executions>
-                        <execution>
-                            <id>timestamp</id>
-                            <phase>validate</phase>
-                            <goals>
-                                <goal>timestamp</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                    <configuration>
-                        <archive>
-                            <addMavenDescriptor>false</addMavenDescriptor>
-                        </archive>
-                    </configuration>
-                </plugin>
                 <plugin>
                     <groupId>pl.project13.maven</groupId>
                     <artifactId>git-commit-id-plugin</artifactId>


### PR DESCRIPTION
Consider updating to the latest version of Tycho, 1.0.0.

New versions of Tycho now have support for TestNG, so this opens up the possibility of running plugin tests under tycho-surefire using TestNG, which seems appropriate :-) See here for more information: https://wiki.eclipse.org/Tycho/Release_Notes/0.26#TestNG_support

Worth noting that this version of Tycho also requires java 8 to run, so I also bumped the "enforcer.java.version" accordingly. Travis already seems to use java 8 to build, so I anticipated no problem with that. The TestNG Eclipse plugin itself remains at java 7.