### PR TITLE
add missing catches to allow compilation...

### DIFF
--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/refactoring/ConvertToYamlAction.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/refactoring/ConvertToYamlAction.java
@@ -65,6 +65,10 @@ public class ConvertToYamlAction extends AbstractHandler {
             TestNGPlugin.log(e1);
           } catch (CoreException e) {
             TestNGPlugin.log(e);
+          } catch (ParserConfigurationException e) {
+            TestNGPlugin.log(e);
+          } catch (SAXException e) {
+            TestNGPlugin.log(e);
           }
         }
       }

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/util/CustomSuite.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/util/CustomSuite.java
@@ -15,6 +15,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import javax.xml.parsers.ParserConfigurationException;
+
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.variables.IStringVariableManager;
@@ -28,6 +30,7 @@ import org.testng.xml.LaunchSuite;
 import org.testng.xml.Parser;
 import org.testng.xml.XmlMethodSelector;
 import org.testng.xml.XmlSuite;
+import org.xml.sax.SAXException;
 
 /**
  * Base class used by classes that generate XML suite files.
@@ -227,6 +230,10 @@ abstract public class CustomSuite extends LaunchSuite {
         }
       }
     } catch (IOException e) {
+      throw new TestNGException(e);
+    } catch (ParserConfigurationException e) {
+      throw new TestNGException(e);
+    } catch (SAXException e) {
       throw new TestNGException(e);
     }
   }


### PR DESCRIPTION
add missing catches to allow compilation against older testng versions (eg., Fedora 24-25)

Signed-off-by: nickboldt <nboldt@redhat.com>