### PR TITLE
allow run xml test suite from context menu of IEditorPart

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,17 @@
 Change Log
 ====
 
+## Current
+
+Supported Metrics:
+
+| Plugin | Dependency |
+| ------------- | ------------- |
+| TestNG for Eclipse | Eclipse Juno (4.2) or above |
+| TestNG M2E Integration (Optional) | M2E 1.5 or above |
+
+* PR #358: allow run xml test suite from context menu of IEditorPart
+
 ## 6.12
 
 Supported Metrics:

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
                 <plugin>
                     <groupId>pl.project13.maven</groupId>
                     <artifactId>git-commit-id-plugin</artifactId>
-                    <version>2.2.2</version>
+                    <version>2.2.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/testng-eclipse-plugin/plugin.xml
+++ b/testng-eclipse-plugin/plugin.xml
@@ -124,25 +124,15 @@
                         value="1">
                   </count>
                   <iterate>
-                    <test property="org.eclipse.debug.ui.matchesPattern" value="*.xml|*.yaml"/>
-                    <instanceof value="org.eclipse.core.resources.IFile"/>
-                    <test property="org.testng.eclipse.isSuite"/>
+                    <adapt type="org.eclipse.core.resources.IResource">
+                       <and>
+                          <test property="org.testng.eclipse.isSuite"/>
+                       </and>
+                    </adapt>
                   </iterate>
                </with>
             </enablement>
          </contextualLaunch>
-         <perspective
-               id="org.eclipse.jdt.ui.JavaPerspective">
-         </perspective>
-         <perspective
-               id="org.eclipse.jdt.ui.JavaHierarchyPerspective">
-         </perspective>
-         <perspective
-               id="org.eclipse.jdt.ui.JavaBrowsingPerspective">
-         </perspective>
-         <perspective
-               id="org.eclipse.debug.ui.DebugPerspective">
-         </perspective>
       </shortcut>
   </extension>
 


### PR DESCRIPTION
before, we can only run the xml test suite from the package explorer, now we can run from context menu of IEditorPart:
![image](https://user-images.githubusercontent.com/555134/31575109-da8c9fc6-b093-11e7-8957-0197a260a686.png)
