### PR TITLE
fixed #357: Surefire 2.17 late replacement: Error: Could not find or load main class @{argLine}

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Supported Metrics:
 
 * PR #358: allow run xml test suite from context menu of IEditorPart
 # Fixed #349: Run As TestNG is not shown for class extending AbstractTestNGCucumberTests. (@vikramvi & Nick Tan)
+# Fixed #357: Surefire 2.17 late replacement: Error: Could not find or load main class @{argLine}. (@kay & Nick Tan)
 
 ## 6.12
 

--- a/testng-maven-eclipse-plugin/src/org/testng/eclipse/maven/MavenTestNGLaunchConfigurationProvider.java
+++ b/testng-maven-eclipse-plugin/src/org/testng/eclipse/maven/MavenTestNGLaunchConfigurationProvider.java
@@ -290,6 +290,12 @@ public class MavenTestNGLaunchConfigurationProvider implements ITestNGLaunchConf
     if (text == null) {
       return text;
     }
+
+    // workaround #357, MavenTestNGLaunchConfigurationProvider does not execute any maven plugin/goal before launching the tests, 
+    //          it simply parses the effective pom xml file.
+    //          so the workaround here is using the init properties value. Aka., the late properties resolution won't be supported.
+    text = text.replace("@{", "${");
+
     if (!text.contains("${")) {
       return text;
     }


### PR DESCRIPTION
https://github.com/cbeust/testng-eclipse/issues/357#issuecomment-334763257