### PR TITLE
Add option to show view only on failures

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Supported Metrics:
 * PR #358: allow run xml test suite from context menu of IEditorPart
 * Fixed #349: Run As TestNG is not shown for class extending AbstractTestNGCucumberTests. (@vikramvi & Nick Tan)
 * Fixed #357: Surefire 2.17 late replacement: Error: Could not find or load main class @{argLine}. (@kay & Nick Tan)
+* PR #362 Add option to show view only on failures (@jan-z)
 
 ## 6.12
 

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGPluginConstants.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/TestNGPluginConstants.java
@@ -31,6 +31,7 @@ public abstract class TestNGPluginConstants {
   public static final String S_SUITE_METHOD_TREATMENT = "suiteMethodTreatment";
   public static final String S_PRE_DEFINED_LISTENERS = "preDefinedListeners";
   public static final String S_SHOW_VIEW_WHEN_TESTS_COMPLETE = "showViewWhenTestComplete";
+  public static final String S_SHOW_VIEW_ON_FAILURE_ONLY = "showViewOnFailureOnly";
   public static final String S_VIEW_TITLE_SHOW_CASE_NAME = "showCaseNameOnViewTitle";
   public static final String S_APPEND_FAVORITE_STATIC_IMPORT = "appendFavoriteStaticImport";
 

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/TestRunnerViewPart.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/TestRunnerViewPart.java
@@ -608,13 +608,13 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
     fProgressBar.refresh(currentSuiteRunInfo.getStatus(), msg);
   }
 
-  private void postShowTestResultsView() {
+  private void postShowTestResultsView(final boolean hasErrors) {
     postSyncRunnable(new Runnable() {
       public void run() {
         if(isDisposed()) {
           return;
         }
-        showTestResultsView();
+        showTestResultsView(hasErrors);
       }
     });
   }
@@ -622,7 +622,7 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
   /**
    * Show the result view.
    */
-  public void showTestResultsView() {
+  public void showTestResultsView(boolean hasErrors) {
     IWorkbenchWindow   window = getSite().getWorkbenchWindow();
     IWorkbenchPage     page = window.getActivePage();
     TestRunnerViewPart testRunner = null;
@@ -633,10 +633,12 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
         // set to do so, otherwise just make sure the view exists
         boolean focusOnView = TestNGPlugin.getDefault().getPreferenceStore()
             .getBoolean(TestNGPluginConstants.S_SHOW_VIEW_WHEN_TESTS_COMPLETE);
+        boolean focusOnFailureOnly = TestNGPlugin.getDefault().getPreferenceStore()
+            .getBoolean(TestNGPluginConstants.S_SHOW_VIEW_ON_FAILURE_ONLY);
 
         testRunner = (TestRunnerViewPart) page.findView(TestRunnerViewPart.NAME);
 
-        if (focusOnView) {
+        if (focusOnView && (!focusOnFailureOnly || (focusOnFailureOnly && hasErrors))) {
           if (testRunner == null) {
             IWorkbenchPart activePart = page.getActivePart();
             testRunner = (TestRunnerViewPart) page
@@ -1352,7 +1354,7 @@ implements IPropertyChangeListener, IRemoteSuiteListener, IRemoteTestListener {
       fNextAction.setEnabled(hasErrors);
       fPrevAction.setEnabled(hasErrors);
       m_rerunFailedAction.setEnabled(hasErrors);
-      postShowTestResultsView();
+      postShowTestResultsView(hasErrors);
       stopTest();
       postSyncRunnable(new Runnable() {
         public void run() {

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/preferences/PreferenceInitializer.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/preferences/PreferenceInitializer.java
@@ -27,6 +27,8 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
     // tests finish running
     store.setDefault(TestNGPluginConstants.S_SHOW_VIEW_WHEN_TESTS_COMPLETE,
         true);
+    store.setDefault(TestNGPluginConstants.S_SHOW_VIEW_ON_FAILURE_ONLY,
+        false);
     store.setDefault(TestNGPluginConstants.S_VIEW_TITLE_SHOW_CASE_NAME,
         true);
     store.setDefault(TestNGPluginConstants.S_APPEND_FAVORITE_STATIC_IMPORT,

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/preferences/WorkspacePreferencePage.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/preferences/WorkspacePreferencePage.java
@@ -33,6 +33,7 @@ public class WorkspacePreferencePage
   private BooleanFieldEditor2 m_absolutePath;
   private BooleanFieldEditor2 m_disabledDefaultListeners;
   private BooleanFieldEditor2 m_showViewWhenTestsComplete;
+  private BooleanFieldEditor2 m_showViewOnFailureOnly;
   private BooleanFieldEditor2 m_showCaseNameOnViewTitle;
   private ResourceSelectionFieldEditor m_xmlTemplateFile;
   private StringFieldEditor m_excludedStackTraces;
@@ -94,6 +95,11 @@ public class WorkspacePreferencePage
         "Show view when tests complete", //$NON-NLS-1$ 
         SWT.NONE, parentComposite);
 
+    m_showViewOnFailureOnly = new BooleanFieldEditor2(
+        TestNGPluginConstants.S_SHOW_VIEW_ON_FAILURE_ONLY,
+        "Show view on failure only", //$NON-NLS-1$ 
+        SWT.NONE, parentComposite);
+
     m_showCaseNameOnViewTitle = new BooleanFieldEditor2(
         TestNGPluginConstants.S_VIEW_TITLE_SHOW_CASE_NAME,
         "Show test name on view title when tests complete", //$NON-NLS-1$ 
@@ -112,6 +118,7 @@ public class WorkspacePreferencePage
     addField(m_absolutePath);
     addField(m_disabledDefaultListeners);
     addField(m_showViewWhenTestsComplete);
+    addField(m_showViewOnFailureOnly);
     addField(m_showCaseNameOnViewTitle);
     addField(m_xmlTemplateFile);
     addField(m_excludedStackTraces);


### PR DESCRIPTION
This patch allows the view to be only shown when there are test failures, just like in the JUnit Plugin.