### PR TITLE
Fixes #408 - Doesn't build against or run on Eclipse 4.10 (2018-12)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Supported Metrics:
 * PR #401: support TestNG 7.0
 * Fixed #348: String index out of range: -2. (@timrsfo & Nick Tan)
 * Fixed #407: eclipse plugin generates invalid java for toString & hashCode (@dabraham02124 & Nick Tan)
+* Fixed #408: Doesn't build against or run on Eclipse 4.10 (2018-12)
 
 ## 6.14
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,17 +53,7 @@
                     <environment>
                       <os>win32</os>
                       <ws>win32</ws>
-                      <arch>x86</arch>
-                    </environment>
-                    <environment>
-                      <os>win32</os>
-                      <ws>win32</ws>
                       <arch>x86_64</arch>
-                    </environment>
-                    <environment>
-                      <os>linux</os>
-                      <ws>gtk</ws>
-                      <arch>x86</arch>
                     </environment>
                     <environment>
                       <os>linux</os>


### PR DESCRIPTION
The internal JDT API StubUtility moved to a different bundle in the
latest version of Eclipse, for details see:

https://github.com/eclipse/eclipse.jdt.ui/commit/bc3bc858da1855f31cee9566912859faac05819e

Also, upstream Eclipse no longer supports 32bit architectures, so
remove those from the target environment configuration in the pom

Signed-off-by: Mat Booth <mat.booth@redhat.com>