### PR TITLE
Fix #512: Fix the internal NPE in codemining processing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Supported Metrics:
 | TestNG M2E Integration (Optional) | M2E 1.5 or above |
 
 * update embedded testng to 7.3.0
+* Fix #512: Fixed a NPE while rendering codeminings 
 
 ## 7.2.0
 

--- a/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/codemining/TestCodeMiningProvider.java
+++ b/testng-eclipse-plugin/src/main/org/testng/eclipse/ui/codemining/TestCodeMiningProvider.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IAnnotation;
@@ -113,9 +114,8 @@ public class TestCodeMiningProvider extends AbstractCodeMiningProvider {
         .filter(a -> "Test".equals(a.getElementName()) || "org.testng.annotations.Test".equals(a.getElementName())).findFirst(); //$NON-NLS-1$ //$NON-NLS-2$
     if(annotation.isPresent()) {
       String[][] resolveType = method.getDeclaringType().resolveType(annotation.get().getElementName());
-      if(resolveType.length > 0) {
-        return Arrays.equals(EXPECTED_TYPE, resolveType[0]);
-      }
+      return Optional.ofNullable(resolveType)
+          .flatMap(r -> Stream.of(r).filter(e -> Arrays.equals(EXPECTED_TYPE, e)).findFirst()).isPresent();
     }
     return false;
   }


### PR DESCRIPTION
This issue is only happening in Eclipse 2021-03 and in
Eclipse 2021-06 I-Builds. The code is fixed work as expected
according to the java doc.